### PR TITLE
Fixes extra space between street name and suffix

### DIFF
--- a/address.go
+++ b/address.go
@@ -40,9 +40,9 @@ func Address() *AddressInfo {
 func Street() (street string) {
 	switch randInt := randIntRange(1, 2); randInt {
 	case 1:
-		street = StreetNumber() + " " + StreetPrefix() + " " + StreetName() + " " + StreetSuffix()
+		street = StreetNumber() + " " + StreetPrefix() + " " + StreetName() + StreetSuffix()
 	case 2:
-		street = StreetNumber() + " " + StreetName() + " " + StreetSuffix()
+		street = StreetNumber() + " " + StreetName() + StreetSuffix()
 	}
 
 	return


### PR DESCRIPTION
Before: ![Before](http://i.imgur.com/SayCcAg.png)

After: ![After](http://i.imgur.com/N53MWWm.png)