### PR TITLE
deterministic behaviour for same key a pattern

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -26,7 +26,7 @@ func Generate(dataVal string) string {
 			catValue = getRandValue([]string{categories[0], categories[1]})
 		}
 
-		dataVal = strings.Replace(dataVal, "{"+replace+"}", catValue, 1)
+		dataVal = strings.Replace(dataVal, "{"+replace+"}", catValue, -1)
 	}
 
 	// Replace # with numbers


### PR DESCRIPTION
A pattern such as  "{name.first}@{name.first}.{internet.domain_suffix}"
would yield "John@Jane.com".
In most use cases, an end user would want one entity to be constant 
across the template, meaning the output should be 
"John@John.com".