### PR TITLE
fix: handle an edge case to avoid panic

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -48,6 +48,9 @@ func getRandIntValue(dataVal []string) int {
 
 // Replace # with numbers
 func replaceWithNumbers(str string) string {
+	if str == "" {
+		return str
+	}
 	bytestr := []byte(str)
 	hashtag := []byte("#")[0]
 	numbers := []byte("0123456789")
@@ -65,6 +68,9 @@ func replaceWithNumbers(str string) string {
 
 // Replace ? with letters
 func replaceWithLetters(str string) string {
+	if str == "" {
+		return str
+	}
 	bytestr := []byte(str)
 	question := []byte("?")[0]
 	letters := []byte("abcdefghijklmnopqrstuvwxyz")

--- a/misc_test.go
+++ b/misc_test.go
@@ -32,6 +32,18 @@ func TestRandFloatRangeSame(t *testing.T) {
 	}
 }
 
+func TestReplaceWithNumbers(t *testing.T) {
+	if "" != replaceWithNumbers("") {
+		t.Error("You should have gotten an empty string")
+	}
+}
+
+func TestReplaceWithLetters(t *testing.T) {
+	if "" != replaceWithLetters("") {
+		t.Error("You should have gotten an empty string")
+	}
+}
+
 func TestCatagories(t *testing.T) {
 	var got, expected []string
 	for k := range Catagories() {


### PR DESCRIPTION
`replaceWithNumbers` panics if the argument is an
empty string.
This case was triggered when Generate() is
called with "{person.invalid}" argument.
This results in an empty string as an argument
to `replaceWithNumbers`.