### PR TITLE
strings.Replace(..., -1) instead of strings.ReplaceAll() for go<1.12

### DIFF
--- a/internet.go
+++ b/internet.go
@@ -25,7 +25,7 @@ func URL() string {
 		slug[i] = BS()
 	}
 	url := "http" + RandString([]string{"s", ""}) + "://www." + DomainName() + "/" + strings.ToLower(strings.Join(slug, "/"))
-	url = strings.ReplaceAll(url, " ", "")
+	url = strings.Replace(url, " ", "", -1)
 
 	return url
 }


### PR DESCRIPTION
To keep compat with go < 1.12, this PR uses `strings.Replace(..., -1)` instead of `strings.ReplaceAll()`.