### PR TITLE
payment - fix bitcoin private key structure

### DIFF
--- a/payment.go
+++ b/payment.go
@@ -176,10 +176,10 @@ func BitcoinAddress() string {
 // BitcoinPrivateKey will generate a random bitcoin private key base58 consisting of numbers, upper and lower characters
 func BitcoinPrivateKey() string {
 	var b strings.Builder
-	for i := 0; i < 50; i++ {
+	for i := 0; i < 49; i++ {
 		b.WriteString(randCharacter(base58))
 	}
-	return "5" + b.String()
+	return "5" + RandomString([]string{"H", "J", "K"}) + b.String()
 }
 
 func addPaymentLookup() {

--- a/payment_test.go
+++ b/payment_test.go
@@ -202,7 +202,7 @@ func BenchmarkBitcoinAddress(b *testing.B) {
 func ExampleBitcoinPrivateKey() {
 	Seed(11)
 	fmt.Println(BitcoinPrivateKey())
-	// Output: 5WjEJ7SnBNJyDjdPUjLuYByYzM9rG1trax8c2NTSBtv7YtR57vz
+	// Output: 5KWjEJ7SnBNJyDjdPUjLuYByYzM9rG1trax8c2NTSBtv7YtR57v
 }
 
 func BenchmarkBitcoinPrivateKey(b *testing.B) {


### PR DESCRIPTION
Apparently the regex I posted in https://github.com/brianvoe/gofakeit/issues/116 was flawed, It actually should be `^5[HJK][1-9A-Za-z][^OIl]{49}$`

This small commit makes output compliant with correct regex