### PR TITLE
Ability to create Faker instance with local rand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+.idea

--- a/faker.go
+++ b/faker.go
@@ -13,3 +13,21 @@ func Seed(seed int64) {
 		rand.Seed(seed)
 	}
 }
+
+type Faker struct {
+	Rand *rand.Rand
+}
+
+func New(seed ...int64) *Faker {
+	var s rand.Source
+
+	if len(seed) > 0 {
+		s = rand.NewSource(seed[0])
+	} else {
+		s = rand.NewSource(time.Now().UTC().UnixNano())
+	}
+
+	return &Faker{
+		rand.New(s),
+	}
+}

--- a/misc.go
+++ b/misc.go
@@ -13,12 +13,26 @@ func Bool() bool {
 	return randIntRange(0, 1) == 1
 }
 
-// UUID (version 4) will generate a random unique identifier based upon random nunbers
+// UUID (version 4) will generate a random unique identifier based upon random numbers
 // Format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 func UUID() string {
+	return uuid(nil)
+}
+
+// UUID (version 4) will generate a random unique identifier based upon random numbers
+// Format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+func (f Faker) UUID() string {
+	return uuid(f.Rand)
+}
+
+func uuid(r *rand.Rand) string {
 	version := byte(4)
 	uuid := make([]byte, 16)
-	rand.Read(uuid)
+	if r != nil {
+		r.Read(uuid)
+	} else {
+		rand.Read(uuid)
+	}
 
 	// Set version
 	uuid[6] = (uuid[6] & 0x0f) | (version << 4)

--- a/misc_test.go
+++ b/misc_test.go
@@ -41,6 +41,30 @@ func BenchmarkUUID(b *testing.B) {
 	}
 }
 
+func TestUUIDF(t *testing.T) {
+	f := New()
+
+	id := f.UUID()
+
+	if len(id) != 36 {
+		t.Errorf("unique length does not equal requested length")
+	}
+}
+
+func ExampleUUIDF() {
+	f := New(11)
+	fmt.Println(f.UUID())
+	// Output: 590c1440-9888-45b0-bd51-a817ee07c3f2
+}
+
+func BenchmarkUUIDF(b *testing.B) {
+	f := New()
+
+	for i := 0; i < b.N; i++ {
+		f.UUID()
+	}
+}
+
 func TestShuffleAnySlice(t *testing.T) {
 	ShuffleAnySlice(nil)           // Should do nothing
 	ShuffleAnySlice("b")           // Should do nothing


### PR DESCRIPTION
This is an example change of what it could like to support a Faker client instance, that does not rely on or seed global `rand`.

Similar to https://github.com/brianvoe/gofakeit/issues/78.

This would give users greater, and potentially simpler, control over how to create fake data and without affecting global state.

I only made a change to a single function for demonstration purposes to start the conversation. Each function would be slightly different, but the idea to avoid breaking changes and keep maintenance simple would be move existing functionality to private functions, and the new receiver methods could call with their `rand` instance. 

I could further work on this if the change is welcome, and I'm open to other suggestions on implementation strategy.