### PR TITLE
fix "I'll" mapped to "I'Ll" when it's the first word

### DIFF
--- a/hacker.go
+++ b/hacker.go
@@ -13,7 +13,7 @@ func (f *Faker) HackerPhrase() string { return hackerPhrase(f.Rand) }
 
 func hackerPhrase(r *rand.Rand) string {
 	words := strings.Split(generate(r, getRandValue(r, []string{"hacker", "phrase"})), " ")
-	words[0] = strings.Title(words[0])
+	words[0] = strings.ToUpper(words[0][0:1]) + words[0][1:]
 	return strings.Join(words, " ")
 }
 


### PR DESCRIPTION
When I tried to generate some random sentences with `HackerPhrase()`, I found something strange:

```
You can't calculate the alarm without quantifying the bluetooth JBOD protocol!
I'Ll connect the digital JBOD card, that should synthesize the SAS array!
You can't synthesize the system without copying the mobile RSS matrix!
We need to bypass the neural AGP monitor!
I'Ll hack the mobile SAS panel, that should parse the TCP bus!
Navigating the sensor won't do anything, we need to back up the haptic JBOD system!
```

Some of the sentences start with `I'Ll` seems incorrect.
It looks like the first `l` of `'ll` was mapped to uppercase unexpectedly, and I believe it should be `I'll`.

The template of this sentence is located here:
https://github.com/brianvoe/gofakeit/blob/0418e53a6281759a8723e4e84ed6ccba44ec5ca7/data/hacker.go#L18

And it is unexpectedly mapped with `strings.Title()` here:
https://github.com/brianvoe/gofakeit/blob/0418e53a6281759a8723e4e84ed6ccba44ec5ca7/hacker.go#L16

Here is the code to test mapping with `strings.Title()`:

``` golang
func main() {
	str := "I'll"

	fmt.Println(strings.Title(str))
	fmt.Println(strings.ToUpper(str[0:1]) + str[1:])
}
```

and here is the result:

```
I'Ll
I'll
```

You can test it online: https://play.golang.org/p/SNxQMBv40Ty

So I think maybe we could keep it simple by just transforming the first letter to uppercase, which is proposed in this pull request.