### PR TITLE
Readme - update function definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ fmt.Printf("%s", f.JumbleWord) // loredlowlh
 All functions also exist as methods on the Faker struct
 ### File
 ```go
-JSON(jo *JSONOptions) []byte
-XML(xo *XMLOptions) []byte
-Extension() string
-MimeType() string
+JSON(jo *JSONOptions) ([]byte, error)
+XML(xo *XMLOptions) ([]byte, error)
+FileExtension() string
+FileMimeType() string
 ```
 
 ### Person
@@ -185,7 +185,7 @@ Contact() *ContactInfo
 Email() string
 Phone() string
 PhoneFormatted() string
-Teams(people []string, teams []string) map[string][]string
+Teams(peopleArray []string, teamsArray []string) map[string][]string
 ```
 
 ### Generate
@@ -239,14 +239,14 @@ BeerStyle() string
 BeerYeast() string
 ```
 
-### Cars
+### Car
 ```go
-Vehicle() *VehicleInfo
+Car() *CarInfo
 CarMaker() string
 CarModel() string
-VehicleType() string
-FuelType() string
-TransmissionGearType() string
+CarType() string
+CarFuelType() string
+CarTransmissionType() string
 ```
 
 ### Words
@@ -282,6 +282,8 @@ Dessert() string
 ```go
 Bool() bool
 UUID() string
+FlipACoin() string
+ShuffleAnySlice(v interface{})
 ```
 
 ### Colors
@@ -295,13 +297,13 @@ SafeColor() string
 ### Internet
 ```go
 URL() string
-ImageURL(width int, height int) string
 DomainName() string
 DomainSuffix() string
 IPv4Address() string
 IPv6Address() string
-StatusCode() string
-SimpleStatusCode() int
+MacAddress() string
+HTTPStatusCode() string
+HTTPStatusCodeSimple() int
 LogLevel(logType string) string
 HTTPMethod() string
 UserAgent() string
@@ -363,7 +365,7 @@ JobTitle() string
 ```go
 HackerAbbreviation() string
 HackerAdjective() string
-HackerIngverb() string
+Hackeringverb() string
 HackerNoun() string
 HackerPhrase() string
 HackerVerb() string
@@ -402,7 +404,7 @@ EmojiAlias() string
 EmojiTag() string
 ```
 
-### Languages
+### Language
 ```go
 Language() string
 LanguageAbbreviation() string
@@ -410,7 +412,7 @@ ProgrammingLanguage() string
 ProgrammingLanguageBest() string
 ```
 
-### Numbers
+### Number
 ```go
 Number(min int, max int) int
 Int8() int8
@@ -432,9 +434,9 @@ RandomInt(i []int) int
 ### String
 ```go
 Digit() string
-DigitN(n int) string
+DigitN(n uint) string
 Letter() string
-LetterN(n int) string
+LetterN(n uint) string
 Lexify(str string) string
 Numerify(str string) string
 ShuffleStrings(a []string)


### PR DESCRIPTION
While updating one of my projects from v3 to v6, I noticed that `SimpleStatusCode` was renamed, but the readme still showed the old one.

I have now gone through all categories mentioned in the readme and verified all function names and arguments.

I have also added some missing ones and made the naming of the headings more consistent (some were singular, some were plural).