### PR TITLE
Add HTTPVersion to the list of fakers

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: [1.14, 1.15]
+        go: [1.14, 1.15, 1.16]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ HTTPStatusCode() string
 HTTPStatusCodeSimple() int
 LogLevel(logType string) string
 HTTPMethod() string
+HTTPVersion() string
 UserAgent() string
 ChromeUserAgent() string
 FirefoxUserAgent() string

--- a/data/internet.go
+++ b/data/internet.go
@@ -5,4 +5,5 @@ var Internet = map[string][]string{
 	"browser":       {"firefox", "chrome", "internetExplorer", "opera", "safari"},
 	"domain_suffix": {"com", "biz", "info", "name", "net", "org", "io"},
 	"http_method":   {"HEAD", "GET", "POST", "PUT", "PATCH", "DELETE"},
+	"http_version":  {"HTTP/1.0", "HTTP/1.1", "HTTP/2.0"},
 }

--- a/internet.go
+++ b/internet.go
@@ -248,6 +248,16 @@ func randomPlatform(r *rand.Rand) string {
 	return randomString(r, platforms)
 }
 
+// HTTPVersion will generate a random http version
+func HTTPVersion() string { return httpVersion(globalFaker.Rand) }
+
+// HTTPVersion will generate a random http version
+func (f *Faker) HTTPVersion() string { return httpVersion(f.Rand) }
+
+func httpVersion(r *rand.Rand) string {
+	return getRandValue(r, []string{"internet", "http_version"})
+}
+
 func addInternetLookup() {
 	AddFuncLookup("url", Info{
 		Display:     "URL",
@@ -400,6 +410,17 @@ func addInternetLookup() {
 		Output:      "int",
 		Generate: func(r *rand.Rand, m *MapParams, info *Info) (interface{}, error) {
 			return httpStatusCodeSimple(r), nil
+		},
+	})
+
+	AddFuncLookup("httpversion", Info{
+		Display:     "HTTP Version",
+		Category:    "internet",
+		Description: "Random http version",
+		Example:     "HTTP/1.1",
+		Output:      "string",
+		Generate: func(r *rand.Rand, m *MapParams, info *Info) (interface{}, error) {
+			return httpVersion(r), nil
 		},
 	})
 }

--- a/internet_test.go
+++ b/internet_test.go
@@ -119,10 +119,22 @@ func ExampleHTTPMethod() {
 	// Output: HEAD
 }
 
+func ExampleHTTPVersion() {
+	Seed(11)
+	fmt.Println(HTTPVersion())
+	// Output: HTTP/1.0
+}
+
 func ExampleFaker_HTTPMethod() {
 	f := New(11)
 	fmt.Println(f.HTTPMethod())
 	// Output: HEAD
+}
+
+func ExampleFaker_HTTPVersion() {
+	f := New(11)
+	fmt.Println(f.HTTPVersion())
+	// Output: HTTP/1.0
 }
 
 func BenchmarkHTTPMethod(b *testing.B) {


### PR DESCRIPTION
- This PR Adds HTTP version to the list of fakers.
- Add go lang 1.16 to the github workflow list (Can travis.yml be removed?)