### PR TITLE
Fix installation instruction for gofakeit cli and gofakeit server

### DIFF
--- a/cmd/gofakeit/README.md
+++ b/cmd/gofakeit/README.md
@@ -4,7 +4,7 @@ All functions are available to run in lowercase and if they require additional p
 
 ### Installation
 ```go
-go get github.com/brianvoe/gofakeit/v6
+go get -u github.com/brianvoe/gofakeit/v6/cmd/gofakeit
 ```
 
 ### Example

--- a/cmd/gofakeitserver/README.md
+++ b/cmd/gofakeitserver/README.md
@@ -4,7 +4,7 @@ All functions are available to run in lowercase as first path and if they take i
 
 ### Installation
 ```go
-go get github.com/brianvoe/gofakeit/v6
+go get -u github.com/brianvoe/gofakeit/v6/cmd/gofakeitserver
 ```
 
 ### Example


### PR DESCRIPTION
Current installation instruction for gofakeit cli and gofakeit server is incorrect. This PR fixes it
