### PR TITLE
Fix slice field loop generation.

### DIFF
--- a/struct.go
+++ b/struct.go
@@ -196,13 +196,13 @@ func rSlice(ra *rand.Rand, t reflect.Type, v reflect.Value, tag string, size int
 	// Grab original size to use if needed for sub arrays
 	ogSize := size
 
-	// If the value has a cap and is less than the size
+	// If the value has a len and is less than the size
 	// use that instead of the requested size
-	elemCap := v.Cap()
-	if elemCap == 0 && size == -1 {
+	elemLen := v.Len()
+	if elemLen == 0 && size == -1 {
 		size = number(ra, 1, 10)
-	} else if elemCap != 0 && (size == -1 || elemCap < size) {
-		size = elemCap
+	} else if elemLen != 0 && (size == -1 || elemLen < size) {
+		size = elemLen
 	}
 
 	// Get the element type

--- a/struct_test.go
+++ b/struct_test.go
@@ -529,3 +529,16 @@ func TestStructSetSubStruct(t *testing.T) {
 
 	RemoveFuncLookup("setstruct")
 }
+
+func TestStructSliceLoopGeneration(t *testing.T) {
+	type S struct {
+		A []string
+	}
+
+	s := &S{}
+	for i := 0; i < 2; i++ {
+		if err := Struct(s); err != nil {
+			t.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Re-filling struct's empty slice field leads to panic. pr addresses the issue.
```go
func TestStructSliceLoopGeneration(t *testing.T) {
        type S struct {
                A []string
        }

        s := &S{}
        for i := 0; i < 2; i++ {
                if err := Struct(s); err != nil {
                        t.Fatal(err)
                }
        }
}
```

```
✗ go test -v -run="^TestStructSliceLoopGeneration$"
panic: reflect: slice index out of range [recovered]
	panic: reflect: slice index out of range

goroutine 6 [running]:
testing.tRunner.func1.2(0x6207a0, 0x6dd420)
	/usr/local/go/src/testing/testing.go:1144 +0x332
testing.tRunner.func1(0xc000001680)
	/usr/local/go/src/testing/testing.go:1147 +0x4b6
panic(0x6207a0, 0x6dd420)
	/usr/local/go/src/runtime/panic.go:965 +0x1b9
reflect.Value.Index(0x61e760, 0xc00000c0d8, 0x197, 0x9, 0xc000056b90, 0x198, 0x0)
	/usr/local/go/src/reflect/value.go:962 +0x1f2
github.com/brianvoe/gofakeit/v6.rSlice(0xc0000767e0, 0x6f2ba0, 0x61e760, 0x61e760, 0xc00000c0d8, 0x197, 0x0, 0x0, 0xffffffffffffffff, 0x60bce7, ...)
	/tmp/gofakeit/struct.go:220 +0x252
github.com/brianvoe/gofakeit/v6.r(0xc0000767e0, 0x6f2ba0, 0x61e760, 0x61e760, 0xc00000c0d8, 0x197, 0x0, 0x0, 0xffffffffffffffff, 0x0, ...)
	/tmp/gofakeit/struct.go:47 +0x33a
github.com/brianvoe/gofakeit/v6.rStruct(0xc0000767e0, 0x6f2ba0, 0x630ac0, 0x630ac0, 0xc00000c0d8, 0x199, 0x0, 0x0, 0x0, 0x0)
	/tmp/gofakeit/struct.go:161 +0x2e6
github.com/brianvoe/gofakeit/v6.r(0xc0000767e0, 0x6f2ba0, 0x630ac0, 0x630ac0, 0xc00000c0d8, 0x199, 0x0, 0x0, 0x0, 0x0, ...)
	/tmp/gofakeit/struct.go:35 +0x485
github.com/brianvoe/gofakeit/v6.rPointer(0xc0000767e0, 0x6f2ba0, 0x618a00, 0x618a00, 0xc00000c0d8, 0x16, 0x0, 0x0, 0x0, 0x0, ...)
	/tmp/gofakeit/struct.go:181 +0x105
github.com/brianvoe/gofakeit/v6.r(0xc0000767e0, 0x6f2ba0, 0x618a00, 0x618a00, 0xc00000c0d8, 0x16, 0x0, 0x0, 0x0, 0x0, ...)
	/tmp/gofakeit/struct.go:33 +0x3da
github.com/brianvoe/gofakeit/v6.structFunc(0xc0000767e0, 0x618a00, 0xc00000c0d8, 0x0, 0x0)
	/tmp/gofakeit/struct.go:27 +0xf0
github.com/brianvoe/gofakeit/v6.Struct(...)
	/tmp/gofakeit/struct.go:17
github.com/brianvoe/gofakeit/v6.TestStructSliceLoopGeneration(0xc000001680)
	/tmp/gofakeit/struct_test.go:540 +0x85
testing.tRunner(0xc000001680, 0x6a3548)
	/usr/local/go/src/testing/testing.go:1194 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1239 +0x2b3
FAIL	github.com/brianvoe/gofakeit/v6	0.005s
```