### PR TITLE
struct - add circle check to avoid stack overflow

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -12,5 +12,5 @@ func Slice(v interface{}) { sliceFunc(globalFaker.Rand, v) }
 func (f *Faker) Slice(v interface{}) { sliceFunc(f.Rand, v) }
 
 func sliceFunc(ra *rand.Rand, v interface{}) {
-	r(ra, reflect.TypeOf(v), reflect.ValueOf(v), "", -1)
+	r(nil, ra, reflect.TypeOf(v), reflect.ValueOf(v), "", -1)
 }

--- a/struct_test.go
+++ b/struct_test.go
@@ -67,6 +67,21 @@ type NestedArray struct {
 	NA []StructArray `fakesize:"2"`
 }
 
+type Circular struct {
+	StructPointer         *Circular
+	StructSlice           []Circular
+	StructPointerSlice    []*Circular
+	StructMapValue        map[string]Circular
+	StructPointerMapKey   map[*Circular]string
+	StructPointerMapValue map[string]*Circular
+	IndirectStructPointer *IndirectCircular
+}
+
+type IndirectCircular struct {
+	Foo        Circular
+	FooPointer *Circular
+}
+
 func ExampleStruct() {
 	Seed(11)
 
@@ -650,5 +665,12 @@ func TestStructSliceLoopGeneration(t *testing.T) {
 		if err := Struct(s); err != nil {
 			t.Fatal(err)
 		}
+	}
+}
+
+func TestCircleStructGeneration(t *testing.T) {
+	c := &Circular{}
+	if err := Struct(c); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
at present the code below would cause stack overflow:
```go
type Circular struct {
	StructPointer         *Circular
	StructSlice           []Circular
	StructPointerSlice    []*Circular
	StructMapValue        map[string]Circular
	StructPointerMapKey   map[*Circular]string
	StructPointerMapValue map[string]*Circular
	IndirectStructPointer *IndirectCircular
}

type IndirectCircular struct {
	Foo        Circular
	FooPointer *Circular
}

func TestCircleStructGeneration(t *testing.T) {
	c := &Circular{}
	if err := gofakeit.Struct(c); err != nil {
		t.Fatal(err)
	}
}
```
I add a circle check to prevent infinite recursion