### PR TITLE
Fix custom function for net.IP

### DIFF
--- a/internet_test.go
+++ b/internet_test.go
@@ -2,6 +2,8 @@ package gofakeit
 
 import (
 	"fmt"
+	"math/rand"
+	"net"
 	"testing"
 )
 
@@ -159,6 +161,33 @@ func BenchmarkHTTPMethod(b *testing.B) {
 			f.HTTPMethod()
 		}
 	})
+}
+
+func ExampleAddFuncLookup_withCustomNetIP() {
+	type Foo struct {
+		IP net.IP `fake:"{ip}"` // https://github.com/brianvoe/gofakeit/issues/202
+	}
+
+	var f Foo
+
+	Seed(11)
+	AddFuncLookup("ip", Info{
+		Category:    "custom",
+		Description: "Random IPv4 Address of type net.IP",
+		Example:     "1.1.1.1",
+		Output:      "net.IP",
+		Generate: func(r *rand.Rand, m *MapParams, info *Info) (interface{}, error) {
+			data := net.IPv4(byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))
+			fmt.Printf("data: %s - %T\n", data, data)
+			return data, nil
+		},
+	})
+	defer RemoveFuncLookup("ip")
+	Struct(&f)
+
+	fmt.Printf("%s - %T", f.IP, f.IP)
+	// Output: data: 152.23.53.100 - net.IP
+	// 152.23.53.100 - net.IP
 }
 
 func ExampleIPv4Address() {

--- a/struct.go
+++ b/struct.go
@@ -45,6 +45,9 @@ func r(ra *rand.Rand, t reflect.Type, v reflect.Value, tag string, size int) err
 	case reflect.Bool:
 		return rBool(ra, v, tag)
 	case reflect.Array, reflect.Slice:
+		if t.Name() != "" && tag != "" {
+			return rStruct(ra, t, v, tag)
+		}
 		return rSlice(ra, t, v, tag, size)
 	case reflect.Map:
 		return rMap(ra, t, v, tag, size)

--- a/struct_test.go
+++ b/struct_test.go
@@ -332,6 +332,96 @@ func TestStructPointer(t *testing.T) {
 	}
 }
 
+func TestCustomArrayType(t *testing.T) {
+	Seed(11)
+	AddFuncLookup("customType", Info{
+		Category:    "custom",
+		Description: "Random int array",
+		Example:     "[1]",
+		Output:      "CustomType",
+		Generate: func(r *rand.Rand, m *MapParams, info *Info) (interface{}, error) {
+			data := make([]int, 1)
+			data[0] = 42
+			return data, nil
+		},
+	})
+	defer RemoveFuncLookup("customType")
+
+	AddFuncLookup("customByte", Info{
+		Category:    "custom",
+		Description: "Random byte",
+		Example:     "[1]",
+		Output:      "byte",
+		Generate: func(r *rand.Rand, m *MapParams, info *Info) (interface{}, error) {
+			data := byte(42)
+			return data, nil
+		},
+	})
+
+	type customType []int
+	var wct struct {
+		WithTag     customType `fake:"{customType}"`
+		WithOutTag  customType
+		IntSlice    []int
+		Char        byte
+		CharWithTag byte `fake:"{customByte}"`
+	}
+	err := Struct(&wct)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	if len(wct.WithTag) != 1 {
+		t.Error("wct slice WithTag is not populated from custom function")
+	}
+	if wct.WithTag[0] != 42 {
+		t.Errorf("wct slice WithTag: want 42, got %d", wct.WithTag[0])
+	}
+
+	if len(wct.WithOutTag) == 0 {
+		t.Error("wct slice WithoutTag is not populated")
+	}
+
+	if len(wct.IntSlice) == 0 {
+		t.Error("wct slice IntSlice is not populated")
+	}
+
+	if wct.IntSlice[0] == wct.WithOutTag[0] {
+		t.Error("two different slices should have different values")
+	}
+
+	if wct.Char == byte(0) {
+		t.Error("wct Char is not populated")
+	}
+
+	if wct.CharWithTag != byte(42) {
+		t.Error("wct CharWithTag is not populated from custom function")
+	}
+}
+
+func TestStructArrayWithInvalidCustomFunc(t *testing.T) {
+	AddFuncLookup("customType", Info{
+		Category:    "custom",
+		Description: "Random int array",
+		Example:     "[1]",
+		Output:      "CustomType",
+		Generate: func(r *rand.Rand, m *MapParams, info *Info) (interface{}, error) {
+			data := make([]int, 1)
+			data[0] = 42
+			return data, nil
+		},
+	})
+	defer RemoveFuncLookup("customType")
+
+	var invalidCustomTag struct {
+		InvalidTag []int `fake:"{customType}"`
+	}
+	err := Struct(&invalidCustomTag)
+	if err.Error() != `strconv.ParseInt: parsing "[42]": invalid syntax` {
+		t.Error(err)
+	}
+
+}
 func TestStructArray(t *testing.T) {
 	Seed(11)
 


### PR DESCRIPTION
A custom function for a type that is internally a slice/array is now
used instead of populating the array with random members.

Refs: #202