### PR TITLE
Replacing go get with go install in README.md

### DIFF
--- a/cmd/gofakeit/README.md
+++ b/cmd/gofakeit/README.md
@@ -6,7 +6,7 @@ All functions are available to run in lowercase and if they require additional p
 ### Installation
 
 ```go
-go get -u github.com/brianvoe/gofakeit/v6/cmd/gofakeit
+go install -v github.com/brianvoe/gofakeit/v6/cmd/gofakeit@latest
 ```
 
 ### Example


### PR DESCRIPTION
Starting in Go 1.17, installing executables with go get is deprecated. go install is the recommended way of installing executables - https://go.dev/doc/go-get-install-deprecation

This merge request adds command that uses go install to install gofakeit cli as a command and works across Go versions.