### PR TITLE
Allow fakesize to accept a range of numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ gofakeit.SetGlobalFaker(faker)
 ## Struct
 
 Gofakeit can generate random data for struct fields. For the most part it covers all the basic type
-as well as some non basic like time.Time.
+as well as some non-basic like time.Time.
 
 Struct fields can also use tags to more specifically generate data for that field type.
 
@@ -110,20 +110,21 @@ import "github.com/brianvoe/gofakeit/v6"
 
 // Create structs with random injected data
 type Foo struct {
-	Str      string
-	Int      int
-	Pointer  *int
-	Name     string         `fake:"{firstname}"`         // Any available function all lowercase
-	Sentence string         `fake:"{sentence:3}"`        // Can call with parameters
-	RandStr  string         `fake:"{randomstring:[hello,world]}"`
-	Number   string         `fake:"{number:1,10}"`       // Comma separated for multiple values
-	Regex    string         `fake:"{regex:[abcdef]{5}}"` // Generate string from regex
-	Map      map[string]int `fakesize:"2"`
-	Array    []string       `fakesize:"2"`
-	Bar 	 Bar
-	Skip     *string        `fake:"skip"`                // Set to "skip" to not generate data for
-	Created  time.Time								     // Can take in a fake tag as well as a format tag
-	CreatedFormat  time.Time `fake:"{year}-{month}-{day}" format:"2006-01-02"`
+	Str           string
+	Int           int
+	Pointer       *int
+	Name          string         `fake:"{firstname}"`         // Any available function all lowercase
+	Sentence      string         `fake:"{sentence:3}"`        // Can call with parameters
+	RandStr       string         `fake:"{randomstring:[hello,world]}"`
+	Number        string         `fake:"{number:1,10}"`       // Comma separated for multiple values
+	Regex         string         `fake:"{regex:[abcdef]{5}}"` // Generate string from regex
+	Map           map[string]int `fakesize:"2"`
+	Array         []string       `fakesize:"2"`
+	ArrayRange    []string       `fakesize:"2,6"`
+    Bar           Bar
+	Skip          *string        `fake:"skip"`                // Set to "skip" to not generate data for
+	Created       time.Time                                   // Can take in a fake tag as well as a format tag
+	CreatedFormat time.Time      `fake:"{year}-{month}-{day}" format:"2006-01-02"`
 }
 
 type Bar struct {

--- a/struct.go
+++ b/struct.go
@@ -133,9 +133,30 @@ func rStruct(ra *rand.Rand, t reflect.Type, v reflect.Value, tag string) error {
 			fs, ok := elementT.Tag.Lookup("fakesize")
 			if ok {
 				var err error
-				size, err = strconv.Atoi(fs)
-				if err != nil {
-					return err
+
+				// Check if size has params separated by ,
+				if strings.Contains(fs, ",") {
+					sizeSplit := strings.SplitN(fs, ",", 2)
+					if len(sizeSplit) == 2 {
+						var sizeMin int
+						var sizeMax int
+
+						sizeMin, err = strconv.Atoi(sizeSplit[0])
+						if err != nil {
+							return err
+						}
+						sizeMax, err = strconv.Atoi(sizeSplit[1])
+						if err != nil {
+							return err
+						}
+
+						size = ra.Intn(sizeMax-sizeMin+1) + sizeMin
+					}
+				} else {
+					size, err = strconv.Atoi(fs)
+					if err != nil {
+						return err
+					}
 				}
 			}
 			err := r(ra, elementT.Type, elementV, fakeTag, size)

--- a/struct_test.go
+++ b/struct_test.go
@@ -83,15 +83,17 @@ func ExampleStruct() {
 	}
 
 	type Foo struct {
-		Str     string
-		Int     int
-		Pointer *int
-		Name    string            `fake:"{firstname}"`
-		Number  string            `fake:"{number:1,10}"`
-		Skip    *string           `fake:"skip"`
-		Array   []string          `fakesize:"2"`
-		Map     map[string]string `fakesize:"2"`
-		Bar     Bar
+		Str        string
+		Int        int
+		Pointer    *int
+		Name       string            `fake:"{firstname}"`
+		Number     string            `fake:"{number:1,10}"`
+		Skip       *string           `fake:"skip"`
+		Array      []string          `fakesize:"2"`
+		ArrayRange []string          `fakesize:"2,6"`
+		Map        map[string]string `fakesize:"2"`
+		MapRange   map[string]string `fakesize:"2,4"`
+		Bar        Bar
 	}
 
 	var f Foo
@@ -104,7 +106,9 @@ func ExampleStruct() {
 	fmt.Printf("%v\n", f.Number)
 	fmt.Printf("%v\n", f.Skip)
 	fmt.Printf("%v\n", f.Array)
+	fmt.Printf("%v\n", f.ArrayRange)
 	fmt.Printf("%v\n", f.Map)
+	fmt.Printf("%v\n", f.MapRange)
 	fmt.Printf("%+v\n", f.Bar)
 
 	// Output: bRMaRx
@@ -114,8 +118,10 @@ func ExampleStruct() {
 	// 1
 	// <nil>
 	// [PtapWYJdn MKgtlxwnq]
-	// map[qanPAKaXS:QFpZysVaHG qclaYkWw:oRLOPxLIok]
-	// {Name:yvqqdH Number:4395457394939876661 Float:2.8838284e+38}
+	// [claYk wfoRL PxLIok qanPAKaXS QFpZysVaHG]
+	// map[DjRRGUns:xdBXGY yvqqdH:eUxcvUVS]
+	// map[Oyrwg:LhewLkDVtD XpYcnVTKpB:eubY jQZsZt:eUpXhOq ynojqPYDrH:HWYKFgji]
+	// {Name:ANhYxKtSH Number:-5807586752746953977 Float:4.558046e+37}
 }
 
 func ExampleFaker_Struct() {
@@ -128,15 +134,17 @@ func ExampleFaker_Struct() {
 	}
 
 	type Foo struct {
-		Str     string
-		Int     int
-		Pointer *int
-		Name    string            `fake:"{firstname}"`
-		Number  string            `fake:"{number:1,10}"`
-		Skip    *string           `fake:"skip"`
-		Array   []string          `fakesize:"2"`
-		Map     map[string]string `fakesize:"2"`
-		Bar     Bar
+		Str        string
+		Int        int
+		Pointer    *int
+		Name       string            `fake:"{firstname}"`
+		Number     string            `fake:"{number:1,10}"`
+		Skip       *string           `fake:"skip"`
+		Array      []string          `fakesize:"2"`
+		ArrayRange []string          `fakesize:"2,6"`
+		Map        map[string]string `fakesize:"2"`
+		MapRange   map[string]string `fakesize:"2,4"`
+		Bar        Bar
 	}
 
 	var f Foo
@@ -150,6 +158,7 @@ func ExampleFaker_Struct() {
 	fmt.Printf("%v\n", f.Skip)
 	fmt.Printf("%v\n", f.Array)
 	fmt.Printf("%v\n", f.Map)
+	fmt.Printf("%v\n", f.MapRange)
 	fmt.Printf("%+v\n", f.Bar)
 
 	// Output: bRMaRx
@@ -159,8 +168,9 @@ func ExampleFaker_Struct() {
 	// 1
 	// <nil>
 	// [PtapWYJdn MKgtlxwnq]
-	// map[qanPAKaXS:QFpZysVaHG qclaYkWw:oRLOPxLIok]
-	// {Name:yvqqdH Number:4395457394939876661 Float:2.8838284e+38}
+	// map[DjRRGUns:xdBXGY yvqqdH:eUxcvUVS]
+	// map[Oyrwg:LhewLkDVtD XpYcnVTKpB:eubY jQZsZt:eUpXhOq ynojqPYDrH:HWYKFgji]
+	// {Name:ANhYxKtSH Number:-5807586752746953977 Float:4.558046e+37}
 }
 
 func ExampleStruct_array() {
@@ -175,8 +185,9 @@ func ExampleStruct_array() {
 	}
 
 	type FooMany struct {
-		Foos  []Foo    `fakesize:"1"`
-		Names []string `fake:"{firstname}" fakesize:"3"`
+		Foos       []Foo    `fakesize:"1"`
+		Names      []string `fake:"{firstname}" fakesize:"3"`
+		NamesRange []string `fake:"{firstname}" fakesize:"3,6"`
 	}
 
 	var fm FooMany
@@ -184,10 +195,12 @@ func ExampleStruct_array() {
 
 	fmt.Printf("%v\n", fm.Foos)
 	fmt.Printf("%v\n", fm.Names)
+	fmt.Printf("%v\n", fm.NamesRange)
 
 	// Output:
 	// [{bRMaRx 8474499440427634498 Paolo 4 <nil>}]
 	// [Santino Carole Enrique]
+	// [Zachery Amie Alice Zachary]
 }
 
 func ExampleFaker_Struct_array() {
@@ -202,8 +215,9 @@ func ExampleFaker_Struct_array() {
 	}
 
 	type FooMany struct {
-		Foos  []Foo    `fakesize:"1"`
-		Names []string `fake:"{firstname}" fakesize:"3"`
+		Foos       []Foo    `fakesize:"1"`
+		Names      []string `fake:"{firstname}" fakesize:"3"`
+		NamesRange []string `fake:"{firstname}" fakesize:"3,6"`
 	}
 
 	var fm FooMany
@@ -211,10 +225,12 @@ func ExampleFaker_Struct_array() {
 
 	fmt.Printf("%v\n", fm.Foos)
 	fmt.Printf("%v\n", fm.Names)
+	fmt.Printf("%v\n", fm.NamesRange)
 
 	// Output:
 	// [{bRMaRx 8474499440427634498 Paolo 4 <nil>}]
 	// [Santino Carole Enrique]
+	// [Zachery Amie Alice Zachary]
 }
 
 func TestStructBasic(t *testing.T) {


### PR DESCRIPTION
This PR adds a range to the `fakesize` struct tag, allowing it to accept both a single number, as well as a comma separated min and max value:
```
type User struct {
	Id         int      `fake:"{number}"`
	Username   string   `fake:"{username}"`
	Notes      []string `fakesize:"8" fake:"{sentences}"`
	Attributes []string `fakesize:"2,4" fake:"{word}"`
}
```

This implementation feels like it fits with the code style in the rest of the repo, but please let me know if there's anything you'd like changed, or anything I've missed!