### PR TITLE
JSON/XML/CSV nil options

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ All functions also exist as methods on the Faker struct
 ### File
 
 ```go
+CSV(co *CSVOptions) ([]byte, error)
 JSON(jo *JSONOptions) ([]byte, error)
 XML(xo *XMLOptions) ([]byte, error)
 FileExtension() string

--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ All functions also exist as methods on the Faker struct
 
 ### File
 
+Passing `nil` to `CSV`, `JSON` or `XML` it will auto generate data using a random set of generators.
+
 ```go
 CSV(co *CSVOptions) ([]byte, error)
 JSON(jo *JSONOptions) ([]byte, error)

--- a/cmd/gofakeitserver/main_test.go
+++ b/cmd/gofakeitserver/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math/rand"
 	"net/url"
 	"strings"
 	"testing"
@@ -35,7 +36,11 @@ func TestGetAllRequests(t *testing.T) {
 		if info.Params != nil && len(info.Params) != 0 {
 			// Loop through params and add fields to mapdata
 			for _, p := range info.Params {
-				if p.Default != "" {
+				// If default is empty and has options randomly pick one
+				if p.Default == "" && len(p.Options) != 0 {
+					mapData.Add(p.Field, p.Options[faker.Rand.Intn(len(p.Options))])
+					continue
+				} else if p.Default != "" {
 					// If p.Type is []uint, then we need to convert it to []string
 					if strings.HasPrefix(p.Type, "[") {
 						// Remove [] from type
@@ -167,7 +172,11 @@ func TestPostAllRequests(t *testing.T) {
 
 			// Loop through params and add fields to mapdata
 			for _, p := range info.Params {
-				if p.Default != "" {
+				// If default is empty and has options randomly pick one
+				if p.Default == "" && len(p.Options) != 0 {
+					mapData[p.Field] = []string{p.Options[rand.Intn(len(p.Options))]}
+					continue
+				} else if p.Default != "" {
 					// If p.Type is []uint, then we need to convert it to []string
 					if strings.HasPrefix(p.Type, "[") {
 						// Remove [] from type

--- a/csv.go
+++ b/csv.go
@@ -13,18 +13,28 @@ import (
 
 // CSVOptions defines values needed for csv generation
 type CSVOptions struct {
-	Delimiter string  `json:"delimiter" xml:"delimiter"`
-	RowCount  int     `json:"row_count" xml:"row_count"`
-	Fields    []Field `json:"fields" xml:"fields"`
+	Delimiter string  `json:"delimiter" xml:"delimiter" fake:"{randomstring:[,,tab]}"`
+	RowCount  int     `json:"row_count" xml:"row_count" fake:"{number:1,10}"`
+	Fields    []Field `json:"fields" xml:"fields" fake:"{internal_exampleFields}"`
 }
 
 // CSV generates an object or an array of objects in json format
+// A nil CSVOptions returns a randomly structured CSV.
 func CSV(co *CSVOptions) ([]byte, error) { return csvFunc(globalFaker.Rand, co) }
 
 // CSV generates an object or an array of objects in json format
+// A nil CSVOptions returns a randomly structured CSV.
 func (f *Faker) CSV(co *CSVOptions) ([]byte, error) { return csvFunc(f.Rand, co) }
 
 func csvFunc(r *rand.Rand, co *CSVOptions) ([]byte, error) {
+	if co == nil {
+		// We didn't get a CSVOptions, so create a new random one
+		err := Struct(&co)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// Check delimiter
 	if co.Delimiter == "" {
 		co.Delimiter = ","

--- a/csv_test.go
+++ b/csv_test.go
@@ -99,6 +99,16 @@ func TestCSVLookup(t *testing.T) {
 	// t.Fatal(fmt.Sprintf("%s", value.([]byte)))
 }
 
+func TestCSVNoOptions(t *testing.T) {
+	Seed(11)
+
+	// if CSVOptions is nil -> get a random CSVOptions
+	_, err := CSV(nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
 func BenchmarkCSVLookup100(b *testing.B) {
 	faker := New(0)
 

--- a/json.go
+++ b/json.go
@@ -9,8 +9,8 @@ import (
 
 // JSONOptions defines values needed for json generation
 type JSONOptions struct {
-	Type     string  `json:"type" xml:"type"` // array or object
-	RowCount int     `json:"row_count" xml:"row_count"`
+	Type     string  `json:"type" xml:"type" fake:"{randomstring:[array,object]}"` // array or object
+	RowCount int     `json:"row_count" xml:"row_count" fake:"{number:1,10}"`
 	Fields   []Field `json:"fields" xml:"fields"`
 	Indent   bool    `json:"indent" xml:"indent"`
 }
@@ -54,14 +54,24 @@ func (okv jsonOrderedKeyVal) MarshalJSON() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// JSON generates an object or an array of objects in json format
+// JSON generates an object or an array of objects in json format.
+// A nil JSONOptions returns a randomly structured JSON.
 func JSON(jo *JSONOptions) ([]byte, error) { return jsonFunc(globalFaker.Rand, jo) }
 
-// JSON generates an object or an array of objects in json format
+// JSON generates an object or an array of objects in json format.
+// A nil JSONOptions returns a randomly structured JSON.
 func (f *Faker) JSON(jo *JSONOptions) ([]byte, error) { return jsonFunc(f.Rand, jo) }
 
 // JSON generates an object or an array of objects in json format
 func jsonFunc(r *rand.Rand, jo *JSONOptions) ([]byte, error) {
+	if jo == nil {
+		// We didn't get a JSONOptions, so create a new random one
+		err := Struct(&jo)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// Check to make sure they passed in a type
 	if jo.Type != "array" && jo.Type != "object" {
 		return nil, errors.New("invalid type, must be array or object")

--- a/json_test.go
+++ b/json_test.go
@@ -352,6 +352,16 @@ func TestJSONNoCount(t *testing.T) {
 	}
 }
 
+func TestJSONNoOptions(t *testing.T) {
+	Seed(11)
+
+	// if JSONOptions is nil -> get a random JSONOptions
+	_, err := JSON(nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
 func BenchmarkJSONLookup100(b *testing.B) {
 	faker := New(0)
 

--- a/lookup.go
+++ b/lookup.go
@@ -45,8 +45,8 @@ type Param struct {
 // Field is used for defining what name and function you to generate for file outuputs
 type Field struct {
 	Name     string    `json:"name"`
-	Function string    `json:"function"`
-	Params   MapParams `json:"params"`
+	Function string    `json:"function" fake:"{randomstring:[firstname,autoincrement]}"`
+	Params   MapParams `json:"params" fake:"skip"`
 }
 
 func init() { initLookup() }

--- a/xml.go
+++ b/xml.go
@@ -11,10 +11,10 @@ import (
 
 // XMLOptions defines values needed for json generation
 type XMLOptions struct {
-	Type          string  `json:"type" xml:"type"` // single or array
+	Type          string  `json:"type" xml:"type" fake:"{randomstring:[array,single]}"` // single or array
 	RootElement   string  `json:"root_element" xml:"root_element"`
 	RecordElement string  `json:"record_element" xml:"record_element"`
-	RowCount      int     `json:"row_count" xml:"row_count"`
+	RowCount      int     `json:"row_count" xml:"row_count" fake:"{number:1,10}"`
 	Fields        []Field `json:"fields" xml:"fields"`
 	Indent        bool    `json:"indent" xml:"indent"`
 }
@@ -128,12 +128,22 @@ func xmlMapLoop(e *xml.Encoder, m *xmlMap) error {
 }
 
 // XML generates an object or an array of objects in json format
+// A nil XMLOptions returns a randomly structured XML.
 func XML(xo *XMLOptions) ([]byte, error) { return xmlFunc(globalFaker.Rand, xo) }
 
 // XML generates an object or an array of objects in json format
+// A nil XMLOptions returns a randomly structured XML.
 func (f *Faker) XML(xo *XMLOptions) ([]byte, error) { return xmlFunc(f.Rand, xo) }
 
 func xmlFunc(r *rand.Rand, xo *XMLOptions) ([]byte, error) {
+	if xo == nil {
+		// We didn't get a XMLOptions, so create a new random one
+		err := Struct(&xo)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// Check to make sure they passed in a type
 	if xo.Type != "single" && xo.Type != "array" {
 		return nil, errors.New("invalid type, must be array or object")

--- a/xml.go
+++ b/xml.go
@@ -11,7 +11,7 @@ import (
 
 // XMLOptions defines values needed for json generation
 type XMLOptions struct {
-	Type          string  `json:"type" xml:"type"` // single or multiple
+	Type          string  `json:"type" xml:"type"` // single or array
 	RootElement   string  `json:"root_element" xml:"root_element"`
 	RecordElement string  `json:"record_element" xml:"record_element"`
 	RowCount      int     `json:"row_count" xml:"row_count"`

--- a/xml_test.go
+++ b/xml_test.go
@@ -239,6 +239,16 @@ func TestXMLLookup(t *testing.T) {
 	}
 }
 
+func TestXMLNoOptions(t *testing.T) {
+	Seed(11)
+
+	// if XMLOptions is nil -> get a random XMLOptions
+	_, err := XML(nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
 func BenchmarkXMLLookup100(b *testing.B) {
 	faker := New(0)
 


### PR DESCRIPTION
This PR enables the generation of JSON and XML when the corresponding option objects are nil.

This is useful when one doesn't care about the structure of the generated JSON/XML as long as it is valid.

Some of the tests check for a well formed `JSONOptions` and fail when it is missing required parameters (eg. `Fields` or `RowCount`). While it may seem that a nil `JSONOptions` would be equally malformed, one can argue that when the options are nil it means that they are *not* specified instead of misspecified.

In that case, we can leverage the gofakeit mechanics to generate a random `JSONOptions`/`XMLOptions`, and proceed with the generation as usual.

Tests pass and code coverage is unchanged.

