### PR TITLE
Reverts 8ac39ba

### DIFF
--- a/address.go
+++ b/address.go
@@ -52,9 +52,9 @@ func street(r *rand.Rand) string {
 	var street = ""
 	switch randInt := randIntRange(r, 1, 2); randInt {
 	case 1:
-		street = streetNumber(r) + " " + streetPrefix(r) + " " + streetName(r) + " " + streetSuffix(r)
+		street = streetNumber(r) + " " + streetPrefix(r) + " " + streetName(r) + streetSuffix(r)
 	case 2:
-		street = streetNumber(r) + " " + streetName(r) + " " + streetSuffix(r)
+		street = streetNumber(r) + " " + streetName(r) + streetSuffix(r)
 	}
 
 	return street

--- a/address_test.go
+++ b/address_test.go
@@ -16,8 +16,8 @@ func ExampleAddress() {
 	fmt.Println(address.Country)
 	fmt.Println(address.Latitude)
 	fmt.Println(address.Longitude)
-	// Output: 364 Unions ville, Norfolk, Ohio 99536
-	// 364 Unions ville
+	// Output: 364 Unionsville, Norfolk, Ohio 99536
+	// 364 Unionsville
 	// Norfolk
 	// Ohio
 	// 99536
@@ -37,8 +37,8 @@ func ExampleFaker_Address() {
 	fmt.Println(address.Country)
 	fmt.Println(address.Latitude)
 	fmt.Println(address.Longitude)
-	// Output: 364 Unions ville, Norfolk, Ohio 99536
-	// 364 Unions ville
+	// Output: 364 Unionsville, Norfolk, Ohio 99536
+	// 364 Unionsville
 	// Norfolk
 	// Ohio
 	// 99536
@@ -74,13 +74,13 @@ func BenchmarkAddress(b *testing.B) {
 func ExampleStreet() {
 	Seed(11)
 	fmt.Println(Street())
-	// Output: 364 Unions ville
+	// Output: 364 Unionsville
 }
 
 func ExampleFaker_Street() {
 	f := New(11)
 	fmt.Println(f.Street())
-	// Output: 364 Unions ville
+	// Output: 364 Unionsville
 }
 
 func BenchmarkStreet(b *testing.B) {

--- a/faker_test.go
+++ b/faker_test.go
@@ -24,7 +24,7 @@ func Example() {
 	// Name: Markus Moen
 	// Email: alaynawuckert@kozey.biz
 	// Phone: 9948995369
-	// Address: 35300 South Roads haven, Miami, Tennessee 58302
+	// Address: 35300 South Roadshaven, Miami, Tennessee 58302
 	// BS: streamline
 	// Beer Name: Pliny The Elder
 	// Color: Gray

--- a/generate_test.go
+++ b/generate_test.go
@@ -47,7 +47,7 @@ func ExampleGenerate() {
 	fmt.Println(Generate("{shuffleints:[1,2,3]}"))
 	fmt.Println(Generate("{number:1,50}"))
 	fmt.Println(Generate("{shufflestrings:[key:value,int:string,1:2,a:b]}"))
-	// Output: Markus Moen ssn is 526643139 and lives at 599 Dale ton
+	// Output: Markus Moen ssn is 526643139 and lives at 599 Daleton
 	// Niche backwards caused.
 	// [1 3 2]
 	// 27
@@ -62,7 +62,7 @@ func ExampleFaker_Generate() {
 	fmt.Println(f.Generate("{shuffleints:[1,2,3]}"))
 	fmt.Println(f.Generate("{number:1,50}"))
 	fmt.Println(f.Generate("{shufflestrings:[key:value,int:string,1:2,a:b]}"))
-	// Output: Markus Moen ssn is 526643139 and lives at 599 Dale ton
+	// Output: Markus Moen ssn is 526643139 and lives at 599 Daleton
 	// Niche backwards caused.
 	// [1 3 2]
 	// 27

--- a/json_test.go
+++ b/json_test.go
@@ -29,8 +29,8 @@ func ExampleJSON_object() {
 	//     "first_name": "Markus",
 	//     "last_name": "Moen",
 	//     "address": {
-	//         "address": "4599 Dale ton, Norfolk, New Jersey 36906",
-	//         "street": "4599 Dale ton",
+	//         "address": "4599 Daleton, Norfolk, New Jersey 36906",
+	//         "street": "4599 Daleton",
 	//         "city": "Norfolk",
 	//         "state": "New Jersey",
 	//         "zip": "36906",
@@ -65,8 +65,8 @@ func ExampleFaker_JSON_object() {
 	//     "first_name": "Markus",
 	//     "last_name": "Moen",
 	//     "address": {
-	//         "address": "4599 Dale ton, Norfolk, New Jersey 36906",
-	//         "street": "4599 Dale ton",
+	//         "address": "4599 Daleton, Norfolk, New Jersey 36906",
+	//         "street": "4599 Daleton",
 	//         "city": "Norfolk",
 	//         "state": "New Jersey",
 	//         "zip": "36906",

--- a/person_test.go
+++ b/person_test.go
@@ -215,8 +215,8 @@ func ExamplePerson() {
 	// Developer
 	// Direct
 	// Paradigm
-	// 369 North Corner bury, Miami, North Dakota 24259
-	// 369 North Corner bury
+	// 369 North Cornerbury, Miami, North Dakota 24259
+	// 369 North Cornerbury
 	// Miami
 	// North Dakota
 	// 24259
@@ -279,8 +279,8 @@ func ExampleFaker_Person() {
 	// Developer
 	// Direct
 	// Paradigm
-	// 369 North Corner bury, Miami, North Dakota 24259
-	// 369 North Corner bury
+	// 369 North Cornerbury, Miami, North Dakota 24259
+	// 369 North Cornerbury
 	// Miami
 	// North Dakota
 	// 24259


### PR DESCRIPTION
Fixes #252 

It looks like historically StreetSuffix has always been used to internally generate random sounding street names, where as one would want a StreetSuffix generator to be true street name suffixes we encounter in real life: 

```
[
  Boulevard,
  Place,
  Road,
  Way,
  Terrace,
  Court,
  Lane,
  Circle,
  Trail,
  Avenue,
  Drive,
  Street
]
```

Perhaps the current StreetSuffix function should be an internal function and the public one generate names from the corresponding list.