### PR TITLE
feat(struct): interpret dash (`-`) as skip

### DIFF
--- a/struct.go
+++ b/struct.go
@@ -138,7 +138,7 @@ func rStruct(f *Faker, t reflect.Type, v reflect.Value, tag string) error {
 			fakeTag, ok := elementT.Tag.Lookup("fake")
 
 			// Check whether or not to skip this field
-			if ok && fakeTag == "skip" {
+			if ok && (fakeTag == "skip" || fakeTag == "-") {
 				// Do nothing, skip it
 				continue
 			}

--- a/struct_test.go
+++ b/struct_test.go
@@ -58,7 +58,7 @@ type IntArray []int
 type StructArray struct {
 	Bars      []*Basic
 	Builds    []BuiltIn
-	Skips     []string  `fake:"skip"`
+	Skips     []string  `fake:"-"`
 	Strings   []string  `fake:"{firstname}" fakesize:"3"`
 	SetLen    [5]string `fake:"{firstname}"`
 	SubStr    [][]string


### PR DESCRIPTION
Tiny addition to avoid errors with libraries that automatically adds tags like json to be skipped with `-`.

In my case, it's an orm generator, to which when I introduced gofakeit and fake tag, it automatically added `fake:"-"` which broke faker.

I managed to manually get fixed changing fake:"-" to fake:"skip".

Amazing library, thanks @brianvoe for all the efforts into it.
