### PR TITLE
struct - fix map custom functions

### DIFF
--- a/struct.go
+++ b/struct.go
@@ -304,7 +304,7 @@ func rMap(f *Faker, t reflect.Type, v reflect.Value, tag string, size int) error
 	}
 
 	// Check if tag exists, if so run custom function
-	if t.Name() != "" && tag != "" {
+	if tag != "" {
 		return rCustom(f, t, v, tag)
 	} else if size > 0 {
 		// NOOP

--- a/struct_test.go
+++ b/struct_test.go
@@ -912,7 +912,7 @@ func TestStructMapWithCustomFunction(t *testing.T) {
 	}
 
 	if v, ok := f.MapCustomFun["abc"]; ok {
-		if v != "value" {
+		if v != "123" {
 			t.Errorf("value didnt equal 123, got %v", v)
 		}
 	} else {

--- a/struct_test.go
+++ b/struct_test.go
@@ -892,3 +892,30 @@ func TestStructArrayWithInvalidCustomFunc(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestStructMapWithCustomFunction(t *testing.T) {
+	AddFuncLookup("custom_map", Info{
+		Generate: func(r *rand.Rand, m *MapParams, info *Info) (interface{}, error) {
+			return map[string]string{"abc": "123"}, nil
+		},
+	})
+	defer RemoveFuncLookup("custom_map")
+
+	type StructMap struct {
+		MapCustomFun map[string]string `fake:"{custom_map}"`
+	}
+	var f StructMap
+
+	err := Struct(&f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v, ok := f.MapCustomFun["abc"]; ok {
+		if v != "value" {
+			t.Errorf("value didnt equal 123, got %v", v)
+		}
+	} else {
+		t.Errorf("map didnt contain 'abc'.")
+	}
+}


### PR DESCRIPTION
When a map type field is defined in a structure, its `t.Name()` will return an empty string and the `fake` tag will be invalid. 
Remove `t.Name()!=""` to fix this error.