### PR TITLE
Add randomint & randomuint func lookup

### DIFF
--- a/generate_test.go
+++ b/generate_test.go
@@ -45,13 +45,17 @@ func ExampleGenerate() {
 	fmt.Println(Generate("{firstname} {lastname} ssn is {ssn} and lives at {street}"))
 	fmt.Println(Generate("{sentence:3}"))
 	fmt.Println(Generate("{shuffleints:[1,2,3]}"))
+	fmt.Println(Generate("{randomint:[-1,2,3,-4]}"))
+	fmt.Println(Generate("{randomuint:[1,2,3,4]}"))
 	fmt.Println(Generate("{number:1,50}"))
 	fmt.Println(Generate("{shufflestrings:[key:value,int:string,1:2,a:b]}"))
 	// Output: Markus Moen ssn is 526643139 and lives at 599 Daleton
 	// Niche backwards caused.
 	// [1 3 2]
-	// 27
-	// [a:b key:value int:string 1:2]
+	// -4
+	// 3
+	// 46
+	// [a:b int:string key:value 1:2]
 }
 
 func ExampleFaker_Generate() {
@@ -60,13 +64,17 @@ func ExampleFaker_Generate() {
 	fmt.Println(f.Generate("{firstname} {lastname} ssn is {ssn} and lives at {street}"))
 	fmt.Println(f.Generate("{sentence:3}"))
 	fmt.Println(f.Generate("{shuffleints:[1,2,3]}"))
+	fmt.Println(f.Generate("{randomint:[1,2,3,-4]}"))
+	fmt.Println(f.Generate("{randomuint:[1,2,3,4]}"))
 	fmt.Println(f.Generate("{number:1,50}"))
 	fmt.Println(f.Generate("{shufflestrings:[key:value,int:string,1:2,a:b]}"))
 	// Output: Markus Moen ssn is 526643139 and lives at 599 Daleton
 	// Niche backwards caused.
 	// [1 3 2]
-	// 27
-	// [a:b key:value int:string 1:2]
+	// -4
+	// 3
+	// 46
+	// [a:b int:string key:value 1:2]
 }
 
 func BenchmarkGenerate(b *testing.B) {

--- a/number.go
+++ b/number.go
@@ -506,6 +506,44 @@ func addNumberLookup() {
 		},
 	})
 
+	AddFuncLookup("randomint", Info{
+		Display:     "Random Int",
+		Category:    "number",
+		Description: "Randomly selected value from a slice of int",
+		Example:     "-1,2,-3,4 => -3",
+		Output:      "int",
+		Params: []Param{
+			{Field: "ints", Display: "Integers", Type: "[]int", Description: "Delimited separated integers"},
+		},
+		Generate: func(r *rand.Rand, m *MapParams, info *Info) (interface{}, error) {
+			ints, err := info.GetIntArray(m, "ints")
+			if err != nil {
+				return nil, err
+			}
+
+			return randomInt(r, ints), nil
+		},
+	})
+
+	AddFuncLookup("randomuint", Info{
+		Display:     "Random Uint",
+		Category:    "number",
+		Description: "Randomly selected value from a slice of uint",
+		Example:     "1,2,3,4 => 4",
+		Output:      "uint",
+		Params: []Param{
+			{Field: "uints", Display: "Unsigned Integers", Type: "[]uint", Description: "Delimited separated unsigned integers"},
+		},
+		Generate: func(r *rand.Rand, m *MapParams, info *Info) (interface{}, error) {
+			uints, err := info.GetUintArray(m, "uints")
+			if err != nil {
+				return nil, err
+			}
+
+			return randomUint(r, uints), nil
+		},
+	})
+
 	AddFuncLookup("hexuint8", Info{
 		Display:     "HexUint8",
 		Category:    "number",


### PR DESCRIPTION
This PR will allow to use randomint & randomuint in struct tags.
As for now, it's not possible and leads to the following error:

```go
strconv.ParseUint: parsing "{randomuint:[1,2,3]}": invalid syntax
```