### PR TITLE
fix: fix miss makezero bug

### DIFF
--- a/xml.go
+++ b/xml.go
@@ -164,7 +164,7 @@ func xmlFunc(f *Faker, xo *XMLOptions) ([]byte, error) {
 	}
 
 	// Get key order by order of fields array
-	keyOrder := make([]string, len(xo.Fields))
+	keyOrder := make([]string, 0, len(xo.Fields))
 	for _, f := range xo.Fields {
 		keyOrder = append(keyOrder, f.Name)
 	}


### PR DESCRIPTION
I was running github actions to run linter [makezero](https://github.com/ashanbrown/makezero) for top github golang repos.

see issues https://github.com/alingse/go-linter-runner/issues/1

and the github actions output https://github.com/alingse/go-linter-runner/actions/runs/9242669752/job/25425781695

```
====================================================================================================
append to slice `keyOrder` with non-zero initialized length at https://github.com/brianvoe/gofakeit/blob/master/xml.go#L16[9](https://github.com/alingse/go-linter-runner/actions/runs/9242669752/job/25425781695#step:4:10):14
====================================================================================================
```

