### PR TITLE
feat: change/assign faked values by implementing transformable interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,41 @@ fmt.Printf("%s", f.Name) // billy
 fmt.Printf("%s", f.Age) // 1990-12-07 04:14:25.685339029 +0000 UTC
 ```
 
+## Recipient types
+
+Assignment of generated values can be controlled by implementing the
+`Recipient` interface. This is useful when working with wrapper types,
+and you want to control the generation of values for the wrapped type (the "receptor").
+
+Types implementing `Recipient` are initially populated with faked values
+just like any other type.
+The value of their receptor is then overwritten, which allows combining
+`Recipient` with `Fakeable`, or controlling the generation of faked
+ values for other non-receptor fields.
+```go
+type Optional[T any] struct {
+	IsSet bool
+	Value T
+}
+
+func (o *Optional[T]) Fake(faker *Faker) (any, error) {
+	return Optional[T]{
+		IsSet: true,
+	}, nil
+}
+
+func (o *Optional[T]) Receptor() reflect.Value {
+	return reflect.ValueOf(&o.Value)
+}
+
+type Foo struct {
+	OptEmail     Optional[string]         `fake:"{email}" fakesize:"3"` // {true naomieroob@kirlin.biz}
+	OptSentences Optional[[]string]       `fake:"{sentence:3}" fakesize:"3"` // {true [Rather daughter including. As whereas late. My as yet.]
+	OptMap       Optional[map[string]int] `fakesize:"2"` // {true map[MuPIU:1906369721605615517 mOItdWIG:5095924209814061526]}
+	Skip         Optional[int]            `fake:"-"` // {false 0}
+}
+```
+
 ## Custom Functions
 
 In a lot of situations you may need to use your own random function usage for your specific needs.

--- a/README.md
+++ b/README.md
@@ -260,6 +260,23 @@ type Foo struct {
 }
 ```
 
+## Transformable types
+Types can implement the `Transformable` interface, allowing to modify their value
+in arbitrary ways after their generation.
+
+```go
+type Prefixer string
+
+func (s *Prefixer) FakeTransform(f *Faker) error {
+	*s = Prefixer(fmt.Sprintf("PREFIX.%s", *s))
+	return nil
+}
+
+type Foo struct {
+    Bar Prefixer `fake:"{word}"` // "PREFIX.Hello"
+}
+```
+
 ## Custom Functions
 
 In a lot of situations you may need to use your own random function usage for your specific needs.

--- a/faker_recipient.go
+++ b/faker_recipient.go
@@ -1,0 +1,44 @@
+package gofakeit
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+// Recipient interface can be implemented by wrapper types to define which field
+// will be set with faked values.
+type Recipient interface {
+	// Receptor method implementation MUST have pointer receiver,
+	// e.g. func (r *R) Receptor().
+	//
+	// Returned value MUST have kind reflect.Pointer, or it will not be settable
+	Receptor() reflect.Value
+}
+
+func isRecipient(t reflect.Type) bool {
+	receiverType := reflect.TypeOf((*Recipient)(nil)).Elem()
+	return t.Implements(receiverType) || reflect.PointerTo(t).Implements(receiverType)
+}
+
+func callReceptor(t reflect.Type, v reflect.Value) (reflect.Value, error) {
+	var receptor reflect.Value
+	if t.Kind() == reflect.Pointer {
+		// Pointer elements need to be initialized first
+		ptrValue := reflect.New(t.Elem())
+		v.Set(ptrValue)
+		receptor = ptrValue.Interface().(Recipient).Receptor()
+	} else {
+		receptor = v.Addr().Interface().(Recipient).Receptor()
+	}
+	if receptor.Kind() != reflect.Pointer {
+		return reflect.Value{}, errors.New("method Receiver MUST return a pointer when implementing Receiver interface")
+	}
+	if !receptor.Elem().CanSet() {
+		return reflect.Value{}, fmt.Errorf("Receptor for type %s is not settable", t)
+	}
+	// Set zero to overwrite default generation.
+	// This is needed to preserve faked values generation for other potential non-receptor fields.
+	receptor.Elem().SetZero()
+	return receptor, nil
+}

--- a/faker_recipient_test.go
+++ b/faker_recipient_test.go
@@ -1,0 +1,310 @@
+package gofakeit
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+type wrapper[T any] struct {
+	Value T
+}
+
+func (o *wrapper[T]) Receptor() reflect.Value {
+	return reflect.ValueOf(&o.Value)
+}
+
+// Check that default fake generation was not broken
+func ExampleRecipient_notags() {
+	f := New(11)
+	type testStruct struct {
+		A struct {
+			B string
+		}
+	}
+	var noTags struct {
+		String    wrapper[string]
+		StringPtr wrapper[*string]
+		Int       wrapper[int]
+		Slice     wrapper[[]string]
+		SlicePtr  wrapper[*[]string]
+		Map       wrapper[map[string]int]
+		MapPtr    wrapper[*map[string]int]
+		Time      wrapper[time.Time]
+		TimePtr   wrapper[*time.Time]
+		Struct    wrapper[testStruct]
+		StructPtr wrapper[*testStruct]
+	}
+	if err := f.Struct(&noTags); err != nil {
+		fmt.Printf("Recipient noTags error: %v", err)
+		return
+	}
+	m, _ := json.MarshalIndent(noTags, "", "\t")
+	fmt.Printf("%s\n", m)
+	// Output:
+	// {
+	// 	"String": {
+	// 		"Value": "mwwv"
+	// 	},
+	// 	"StringPtr": {
+	// 		"Value": "AeAwVH"
+	// 	},
+	// 	"Int": {
+	// 		"Value": 3790609878067081083
+	// 	},
+	// 	"Slice": {
+	// 		"Value": [
+	// 			"CQyzjqs",
+	// 			"gaHqIpy",
+	// 			"seUxvh",
+	// 			"GVEnWigE",
+	// 			"VzByQJJXM",
+	// 			"GyLfLRuh",
+	// 			"RHQq",
+	// 			"MyOwqYsV",
+	// 			"XYHS",
+	// 			"aXQHvLvfsQ"
+	// 		]
+	// 	},
+	// 	"SlicePtr": {
+	// 		"Value": [
+	// 			"oQVw",
+	// 			"jEFvDCErTA",
+	// 			"bMGl",
+	// 			"soNQiOZ",
+	// 			"QJUI",
+	// 			"rmnR",
+	// 			"fuGl",
+	// 			"HAUoyWW",
+	// 			"PnBNKbb"
+	// 		]
+	// 	},
+	// 	"Map": {
+	// 		"Value": {
+	// 			"BWuMS": 7323578435895571780,
+	// 			"DNjxfzPeq": 556126185402360932,
+	// 			"EIZKArbndP": 6017639345642484830,
+	// 			"JRLWHfau": 504481847486751011,
+	// 			"ejKE": 2170064023810017206,
+	// 			"nqmqrtj": 2085803212000261243,
+	// 			"qjTyxj": 4814308557197142590,
+	// 			"qlirZp": 366677794067212421
+	// 		}
+	// 	},
+	// 	"MapPtr": {
+	// 		"Value": {
+	// 			"AdXkaOVB": 6747100307432224147,
+	// 			"BZRr": 2090942964323674902,
+	// 			"MAfKVViKzL": 6399228998106268675,
+	// 			"OYMnl": 9084218315452557071,
+	// 			"QMKdaijT": 3319565698096787296,
+	// 			"SDUGngYTGP": 8106940092362766713,
+	// 			"uOmmoA": 7076386249594780656,
+	// 			"uipZzPwyhH": 6533871989415815454
+	// 		}
+	// 	},
+	// 	"Time": {
+	// 		"Value": "1920-08-01T14:50:27.045347196Z"
+	// 	},
+	// 	"TimePtr": {
+	// 		"Value": "1933-03-10T05:22:34.252653011Z"
+	// 	},
+	// 	"Struct": {
+	// 		"Value": {
+	// 			"A": {
+	// 				"B": "cRXwiWI"
+	// 			}
+	// 		}
+	// 	},
+	// 	"StructPtr": {
+	// 		"Value": {
+	// 			"A": {
+	// 				"B": "GfgLRoSjK"
+	// 			}
+	// 		}
+	// 	}
+	// }
+}
+
+// Basic examples with scalar types
+func ExampleRecipient_tags() {
+	f := New(1)
+	var withTags struct {
+		Skip     wrapper[string]  `fake:"-"`
+		Sentence wrapper[string]  `fake:"{sentence:5}"`
+		Email    wrapper[string]  `fake:"{email}"`
+		EmailPtr wrapper[*string] `fake:"{email}"`
+		Int      wrapper[int]     `fake:"{number:1,3}"`
+	}
+	if err := f.Struct(&withTags); err != nil {
+		fmt.Printf("Recipient withTags error: %v", err)
+		return
+	}
+	m, _ := json.MarshalIndent(withTags, "", "\t")
+	fmt.Printf("%s\n", m)
+	// Output:
+	// {
+	// 	"Skip": {
+	// 		"Value": ""
+	// 	},
+	// 	"Sentence": {
+	// 		"Value": "Honour while Bismarckian example product."
+	// 	},
+	// 	"Email": {
+	// 		"Value": "lacybogan@schulist.com"
+	// 	},
+	// 	"EmailPtr": {
+	// 		"Value": "devinmohr@ebert.info"
+	// 	},
+	// 	"Int": {
+	// 		"Value": 1
+	// 	}
+	// }
+}
+
+// Examples with maps/slices, check that fakesize works
+func ExampleRecipient_map_slice_tags() {
+	f := New(1)
+	var withTagMapSlice struct {
+		SliceStr    wrapper[[]string]          `fake:"{firstname}" fakesize:"2"`
+		SliceStrPtr wrapper[*[]string]         `fake:"{sentence:3}" fakesize:"1"`
+		Map         wrapper[map[string]string] `fakesize:"2"`
+	}
+	if err := f.Struct(&withTagMapSlice); err != nil {
+		fmt.Printf("Recipient withTagMapSlice error: %v", err)
+		return
+	}
+	m, _ := json.MarshalIndent(withTagMapSlice, "", "\t")
+	fmt.Printf("%s\n", m)
+	// Output:
+	// {
+	// 	"SliceStr": {
+	// 		"Value": [
+	// 			"Kailyn",
+	// 			"Donny"
+	// 		]
+	// 	},
+	// 	"SliceStrPtr": {
+	// 		"Value": [
+	// 			"Alternatively phew trousers."
+	// 		]
+	// 	},
+	// 	"Map": {
+	// 		"Value": {
+	// 			"AZspPNGDKv": "CJmo",
+	// 			"usUDZFHd": "wNCmJy"
+	// 		}
+	// 	}
+	// }
+}
+
+func ExampleRecipient_time() {
+	f := New(18)
+	type recipient struct {
+		Time       wrapper[time.Time]
+		TimeMonth  wrapper[time.Time] `fake:"{year}-{month}" format:"2006-1"`
+		TimeFormat wrapper[time.Time] `fake:"{year}-{month}-{day}" format:"2006-1-1"`
+	}
+	var r recipient
+	err := f.Struct(&r)
+	if err != nil {
+		fmt.Printf("%v\n", err)
+	}
+	m, _ := json.MarshalIndent(r, "", "\t")
+	fmt.Printf("%s\n", m)
+
+	// Output:
+	// {
+	// 	"Time": {
+	// 		"Value": "1909-11-11T21:39:33.574884884Z"
+	// 	},
+	// 	"TimeMonth": {
+	// 		"Value": "1941-09-01T00:00:00Z"
+	// 	},
+	// 	"TimeFormat": {
+	// 		"Value": "1996-08-01T00:00:00Z"
+	// 	}
+	// }
+}
+
+func TestRecipient_customTag(t *testing.T) {
+	AddFuncLookup("customTag", Info{
+		Category:    "custom",
+		Description: "Random int array",
+		Example:     "[1]",
+		Output:      "CustomType",
+		Generate: func(f *Faker, m *MapParams, info *Info) (any, error) {
+			data := make([]int, 1)
+			data[0] = 42
+			return data, nil
+		},
+	})
+	defer RemoveFuncLookup("customTag")
+
+	type customType []int
+	var withCustomTag struct {
+		A     wrapper[customType]   `fake:"{customTag}"`
+		Array wrapper[[]customType] `fake:"{customTag}"`
+	}
+	if err := Struct(&withCustomTag); err != nil {
+		t.Errorf("Recipient withCustomTag error: %v", err)
+	}
+	if len(withCustomTag.A.Value) != 1 || withCustomTag.A.Value[0] != 42 {
+		t.Errorf("custom tag expected to generate [42], got %v", withCustomTag.A.Value)
+	}
+	if withCustomTag.Array.Value[0][0] != 42 {
+		t.Error("withCustomTag.Array is not populated from custom function")
+	}
+}
+
+type fakeableRecipient[T any] struct {
+	Faked string // populated by Fake()
+	Value T
+}
+
+func (fr *fakeableRecipient[T]) Fake(faker *Faker) (any, error) {
+	return fakeableRecipient[T]{
+		Faked: "faked",
+	}, nil
+}
+
+func (fr *fakeableRecipient[T]) Receptor() reflect.Value {
+	return reflect.ValueOf(&fr.Value)
+}
+
+func TestRecipient_fakeable(t *testing.T) {
+
+	var withFakeable struct {
+		R fakeableRecipient[string] `fake:"{email}"`
+	}
+	if err := Struct(&withFakeable); err != nil {
+		t.Errorf("Recipient withFakeable error: %v\n", err)
+	}
+	if withFakeable.R.Faked != "faked" {
+		t.Errorf("withFakeable: expected string 'faked', got: '%s'", withFakeable.R.Faked)
+	}
+	if !strings.Contains(withFakeable.R.Value, "@") {
+		t.Errorf("withFakeable: expected generated value to be email-like, got: '%s'", withFakeable.R.Value)
+	}
+}
+
+type Wrapper[T any] wrapper[T]
+
+func (o *Wrapper[T]) Receptor() reflect.Value {
+	return reflect.ValueOf(&o.Value)
+}
+func TestRecipient_embed(t *testing.T) {
+
+	var withEmbed struct {
+		Wrapper[string] `fake:"{email}"`
+	}
+	if err := Struct(&withEmbed); err != nil {
+		t.Errorf("Recipient withEmbed error: %v\n", err)
+	}
+	if !strings.Contains(withEmbed.Value, "@") {
+		t.Errorf("Recipient withEmbed: expected email-like value, got '%s'", withEmbed.Value)
+	}
+}

--- a/faker_transformable.go
+++ b/faker_transformable.go
@@ -1,0 +1,35 @@
+package gofakeit
+
+import (
+	"errors"
+	"reflect"
+)
+
+// Transformable interface can be implemented to arbitrarily transform the value
+// of a type after it was generated.
+type Transformable interface {
+	// FakeTransform method implementation must have pointer receiver,
+	// so that the Transformable can be mutated.
+	FakeTransform(faker *Faker) error
+}
+
+func isTransformable(t reflect.Type) bool {
+	transformableType := reflect.TypeOf((*Transformable)(nil)).Elem()
+	return t.Implements(transformableType) || reflect.PointerTo(t).Implements(transformableType)
+}
+
+func callTransform(faker *Faker, v reflect.Value) error {
+	var (
+		f  Transformable
+		ok bool
+	)
+	if v.Type().Kind() == reflect.Pointer {
+		f, ok = v.Interface().(Transformable)
+	} else {
+		f, ok = v.Addr().Interface().(Transformable)
+	}
+	if !ok {
+		return errors.New("not a Transformable type")
+	}
+	return f.FakeTransform(faker)
+}

--- a/faker_transformable_test.go
+++ b/faker_transformable_test.go
@@ -1,0 +1,65 @@
+package gofakeit
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type prefixer string
+
+func (s *prefixer) FakeTransform(f *Faker) error {
+	*s = prefixer(fmt.Sprintf("PREFIX.%s", *s))
+	return nil
+}
+
+func TestTransformable(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		var p prefixer
+		if err := Struct(&p); err != nil {
+			t.Fatalf("transformable error: %v", err)
+		}
+		if !strings.HasPrefix(string(p), "PREFIX.") {
+			t.Errorf("Prefix transformable: missing prefix, got %s", string(p))
+		}
+	})
+
+	t.Run("struct", func(t *testing.T) {
+		var transformFields struct {
+			P1      prefixer
+			P2      *prefixer
+			Wrapped wrapper[prefixer] `fake:"{email}"`
+		}
+		if err := Struct(&transformFields); err != nil {
+			t.Fatalf("transformable error: %v", err)
+		}
+		if !strings.HasPrefix(string(transformFields.P1), "PREFIX.") {
+			t.Errorf(
+				"P1 transformable: missing prefix, got %s",
+				string(transformFields.P1),
+			)
+		}
+		if !strings.HasPrefix(string(*transformFields.P2), "PREFIX.") {
+			t.Errorf(
+				"P2 transformable: missing prefix, got %s",
+				string(*transformFields.P2),
+			)
+		}
+		if strings.HasPrefix(string(*transformFields.P2), "PREFIX.PREFIX.") {
+			t.Errorf("FakeTransform called multiple times")
+		}
+		if !strings.HasPrefix(string(transformFields.Wrapped.Value), "PREFIX.") {
+			t.Errorf(
+				"Wrapped transformable: missing prefix, got %s",
+				string(transformFields.Wrapped.Value),
+			)
+		}
+		if !strings.Contains(string(transformFields.Wrapped.Value), "@") {
+			t.Errorf(
+				"Wrapped transformable: expected email-like string, got '%s'",
+				string(transformFields.Wrapped.Value),
+			)
+		}
+	})
+
+}

--- a/struct.go
+++ b/struct.go
@@ -29,7 +29,7 @@ func structFunc(f *Faker, v any) error {
 	return r(f, reflect.TypeOf(v), reflect.ValueOf(v), "", 0)
 }
 
-func r(f *Faker, t reflect.Type, v reflect.Value, tag string, size int) error {
+func r(f *Faker, t reflect.Type, v reflect.Value, tag string, size int) (err error) {
 	// Handle special types
 
 	if t.PkgPath() == "encoding/json" {
@@ -45,6 +45,14 @@ func r(f *Faker, t reflect.Type, v reflect.Value, tag string, size int) error {
 		default:
 			return errors.New("unknown encoding/json type: " + t.Name())
 		}
+	}
+
+	// Transform value if is transformable after generation
+	// Ignore pointer to avoid double call
+	if isTransformable(t) && t.Kind() != reflect.Pointer {
+		defer func() {
+			err = callTransform(f, v)
+		}()
 	}
 
 	// Handle generic types

--- a/struct.go
+++ b/struct.go
@@ -158,6 +158,20 @@ func rStruct(f *Faker, t reflect.Type, v reflect.Value, tag string) error {
 			continue
 		}
 
+		if isRecipient(elementT.Type) {
+			// First generate faked values as normal, e.g. for non-receptor fields
+			if err := r(f, elementT.Type, elementV, "", -1); err != nil {
+				return err
+			}
+			// Grab receptor and use it instead of current struct field
+			receptor, err := callReceptor(elementT.Type, elementV)
+			if err != nil {
+				return err
+			}
+			elementV = receptor.Elem()
+			elementT.Type = elementV.Type()
+		}
+
 		// Check if reflect type is of values we can specifically set
 		elemStr := elementT.Type.String()
 		switch elemStr {


### PR DESCRIPTION
This small feature introduces the `Transformable` interface which can be implemented to capture generated values and assign them as needed on a `Transformable`. Example use case is an option type : 

```go
type Optional[T any] struct {
	IsSet bool
	Value T
}

func (o *Optional[T]) FakeTransform(f *Faker, v any) error {
	o.IsSet = true
	o.Value = v.(T)
	return nil
}

type Container struct {
	MaybeText  Optional[string] `fake:"{sentence:5}"`
	MaybeEmail Optional[string] `fake:"{email}"`
	MaybeSlice Optional[[]string]
	MaybeAge   Optional[int] `fake:"{number:0,120}"`
}
```