### PR TITLE
docs: remove non-existent functions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,7 +788,6 @@ EmojiSentence() string
 Language() string
 LanguageAbbreviation() string
 ProgrammingLanguage() string
-ProgrammingLanguageBest() string
 ```
 
 ### Number
@@ -886,7 +885,6 @@ ErrorGRPC() error
 ErrorHTTP() error
 ErrorHTTPClient() error
 ErrorHTTPServer() error
-ErrorInput() error
 ErrorRuntime() error
 ```
 


### PR DESCRIPTION
Remove ProgrammingLanguageBest() and ErrorInput() function references from README as these functions are not implemented in the codebase.