### PR TITLE
fix: at least one char per enabled set in Password()

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -113,7 +113,15 @@ func password(f *Faker, lower bool, upper bool, numeric bool, special bool, spac
 
 	// Create byte slice
 	b := make([]byte, num)
-	for i := range b {
+
+	// Guarantee at least one character from each enabled non-space group so
+	// the password always satisfies the requested character-set criteria.
+	for i, g := range nonSpace {
+		b[i] = g.chars[f.IntN(len(g.chars))]
+	}
+
+	// Fill the remaining positions randomly from all active groups.
+	for i := len(nonSpace); i < num; i++ {
 		b[i] = draw(active, totalWeight)
 	}
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -2,6 +2,7 @@ package gofakeit
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -49,6 +50,43 @@ func TestPassword(t *testing.T) {
 	}
 }
 
+func TestPasswordCharacterSetGuarantee(t *testing.T) {
+	// Every generated password must contain at least one character from each
+	// enabled character set, regardless of length or randomness.
+	for i := 0; i < 1000; i++ {
+		pass := Password(true, true, true, true, false, 8)
+
+		var hasLower, hasUpper, hasNumeric, hasSpecial bool
+		for _, c := range pass {
+			if strings.ContainsRune(lowerStr, c) {
+				hasLower = true
+			}
+			if strings.ContainsRune(upperStr, c) {
+				hasUpper = true
+			}
+			if strings.ContainsRune(numericStr, c) {
+				hasNumeric = true
+			}
+			if strings.ContainsRune(specialSafeStr, c) {
+				hasSpecial = true
+			}
+		}
+
+		if !hasLower {
+			t.Errorf("iteration %d: password %q missing lowercase character", i, pass)
+		}
+		if !hasUpper {
+			t.Errorf("iteration %d: password %q missing uppercase character", i, pass)
+		}
+		if !hasNumeric {
+			t.Errorf("iteration %d: password %q missing numeric character", i, pass)
+		}
+		if !hasSpecial {
+			t.Errorf("iteration %d: password %q missing special character", i, pass)
+		}
+	}
+}
+
 func ExamplePassword() {
 	Seed(11)
 	fmt.Println(Password(true, false, false, false, false, 32))
@@ -58,12 +96,12 @@ func ExamplePassword() {
 	fmt.Println(Password(true, true, true, true, true, 32))
 	fmt.Println(Password(true, true, true, true, true, 4))
 
-	// Output: tcvncypbfolpftvlyplgdxiwibpsautg
-	// ZXVXDVFQGCECFDBRWEKPWATHKRGKWDIZ
-	// 78902501101475351179812748788830
-	// !!._-._*--@@.@---@_@.-_!_!-*_!*@
-	// 96 rvcB@f0.PNzL!qp 7hP_V 7g!vV 9
-	// 6hJDB
+	// Output: bakyxpaaiytqtynbqyfssyhweynxkxhf
+	// DPETVGIXXHDGKFXKBZEAQRKZRFDCWVWC
+	// 98102640783120607214363311930963
+	// --*!_---!__!@--.!_.!@*--@.@__*@*
+	// 63.0NpLPR Pv9 h! c!V *gzBv97rvf7
+	// mZO-4
 }
 
 func ExampleFaker_Password() {
@@ -75,12 +113,12 @@ func ExampleFaker_Password() {
 	fmt.Println(f.Password(true, true, true, true, true, 32))
 	fmt.Println(f.Password(true, true, true, true, true, 4))
 
-	// Output: tcvncypbfolpftvlyplgdxiwibpsautg
-	// ZXVXDVFQGCECFDBRWEKPWATHKRGKWDIZ
-	// 78902501101475351179812748788830
-	// !!._-._*--@@.@---@_@.-_!_!-*_!*@
-	// 96 rvcB@f0.PNzL!qp 7hP_V 7g!vV 9
-	// 6hJDB
+	// Output: bakyxpaaiytqtynbqyfssyhweynxkxhf
+	// DPETVGIXXHDGKFXKBZEAQRKZRFDCWVWC
+	// 98102640783120607214363311930963
+	// --*!_---!__!@--.!_.!@*--@.@__*@*
+	// 63.0NpLPR Pv9 h! c!V *gzBv97rvf7
+	// mZO-4
 }
 
 func BenchmarkPassword(b *testing.B) {

--- a/csv_test.go
+++ b/csv_test.go
@@ -25,9 +25,9 @@ func ExampleCSV_array() {
 	fmt.Println(string(value))
 
 	// Output: id,first_name,last_name,password
-	// 1,Priscilla,Thornton,3lGftNp9S908
-	// 2,Shaun,Byrd,Lc3G00tpPp7U
-	// 3,Grady,Craig,LGAvzZ5xUB6Z
+	// 1,Priscilla,Thornton,F395YfK9tHs9
+	// 2,Emmett,Black,PL0G37o1pY0p
+	// 3,Liza,Vincent,q11fR4MwsM4N
 }
 
 func ExampleFaker_CSV_array() {
@@ -49,9 +49,9 @@ func ExampleFaker_CSV_array() {
 	fmt.Println(string(value))
 
 	// Output: id,first_name,last_name,password
-	// 1,Priscilla,Thornton,3lGftNp9S908
-	// 2,Shaun,Byrd,Lc3G00tpPp7U
-	// 3,Grady,Craig,LGAvzZ5xUB6Z
+	// 1,Priscilla,Thornton,F395YfK9tHs9
+	// 2,Emmett,Black,PL0G37o1pY0p
+	// 3,Liza,Vincent,q11fR4MwsM4N
 }
 
 func TestCSVLookup(t *testing.T) {

--- a/datetime_test.go
+++ b/datetime_test.go
@@ -10,14 +10,14 @@ func ExampleDate() {
 	Seed(11)
 	fmt.Println(Date())
 
-	// Output: 2012-11-07 04:31:13.726582492 +0000 UTC
+	// Output: 2013-11-07 04:31:13.726582492 +0000 UTC
 }
 
 func ExampleFaker_Date() {
 	f := New(11)
 	fmt.Println(f.Date())
 
-	// Output: 2012-11-07 04:31:13.726582492 +0000 UTC
+	// Output: 2013-11-07 04:31:13.726582492 +0000 UTC
 }
 
 func TestDateLookup(t *testing.T) {
@@ -188,14 +188,14 @@ func ExampleYear() {
 	Seed(11)
 	fmt.Println(Year())
 
-	// Output: 2012
+	// Output: 2013
 }
 
 func ExampleFaker_Year() {
 	f := New(11)
 	fmt.Println(f.Year())
 
-	// Output: 2012
+	// Output: 2013
 }
 
 func BenchmarkYear(b *testing.B) {

--- a/faker_test.go
+++ b/faker_test.go
@@ -34,7 +34,7 @@ func Example() {
 	// Credit Card: 6449062052570938760
 	// Hacker Phrase: I'll override the back-end USB system, that should encrypt the SCSI port!
 	// Job Title: Journalist
-	// Password: 4i86u.-1.NM4DtZ5M@!@-.Cz4vY*wTqs
+	// Password: @M85m-v-4Nt*4T4.qsuw!.MC1Y68i@D.
 }
 
 func ExampleNew() {

--- a/generate_test.go
+++ b/generate_test.go
@@ -246,9 +246,9 @@ func ExampleFixedWidth() {
 	fmt.Println(string(value))
 
 	// Output: Name                   Email                          Password         Age
-	// Priscilla Thornton     laurelmcclure@wiley.org        L43ypoSV1tDf     62
-	// Brooke Duncan          ramonblack@rutherford.io       rSM78E2ncUt3     9
-	// Gregg Ford             roxannewalsh@hamilton.name     DUB69zQ1WZx8     77
+	// Priscilla Thornton     laurelmcclure@wiley.org        93Ya9ABSa4kq     92
+	// Brooke Duncan          ramonblack@rutherford.io       US8ptM3c2T07     64
+	// Gregg Ford             roxannewalsh@hamilton.name     4wP4V90iMs44     59
 }
 
 func ExampleFixedWidth_default() {
@@ -262,15 +262,15 @@ func ExampleFixedWidth_default() {
 	fmt.Println(string(value))
 
 	// Output: Name                  Email                        Password
-	// Nannie Duncan         lancegraves@sandoval.io      1T2elqD45w8N
-	// Brooklyn Maxwell      danykaadams@morgan.com       V444uNv59i04
-	// Carmen Romero         robinjenkins@cormier.com     eiZz6ipistlz
-	// Hailie Wiley          buddypearson@summers.io      623DddowdELF
-	// Marion Wallace        emmettblack@mcdermott.io     3Ydc69Z00Mcj
-	// Amalia Rutherford     aprilmuller@joseph.net       31mk7arUdpNi
-	// Roxane Webb           jaywashington@barton.net     t9fPK4m8497T
-	// Randy Hamilton        caseybartell@myers.biz       x4KU3IhQ6im7
-	// Elliott Jacobson      janierussell@bailey.io       5aHeXXT8vjF5
+	// Nannie Duncan         lancegraves@sandoval.io      n7iSUr2MWt8c
+	// Brooklyn Maxwell      danykaadams@morgan.com       4v940LNiV44s
+	// Carmen Romero         robinjenkins@cormier.com     472CR3CDG0ke
+	// Hailie Wiley          buddypearson@summers.io      Hd692w44DlzL
+	// Marion Wallace        emmettblack@mcdermott.io     K187He5tUfFj
+	// Amalia Rutherford     aprilmuller@joseph.net       2ibBGsrc0mW3
+	// Roxane Webb           jaywashington@barton.net     s0HNN9fkEL1u
+	// Randy Hamilton        caseybartell@myers.biz       ORe9uGIuP4m0
+	// Elliott Jacobson      janierussell@bailey.io       Hd5Kl6T2g7pi
 }
 
 func ExampleFixedWidth_noHeader() {
@@ -291,9 +291,9 @@ func ExampleFixedWidth_noHeader() {
 
 	fmt.Println(value)
 
-	// Output: Priscilla Thornton     laurelmcclure@wiley.org        L43ypoSV1tDf     62
-	// Brooke Duncan          ramonblack@rutherford.io       rSM78E2ncUt3     9
-	// Gregg Ford             roxannewalsh@hamilton.name     DUB69zQ1WZx8     77
+	// Output: Priscilla Thornton     laurelmcclure@wiley.org        93Ya9ABSa4kq     92
+	// Brooke Duncan          ramonblack@rutherford.io       US8ptM3c2T07     64
+	// Gregg Ford             roxannewalsh@hamilton.name     4wP4V90iMs44     59
 }
 
 func ExampleFaker_FixedWidth() {
@@ -315,9 +315,9 @@ func ExampleFaker_FixedWidth() {
 	fmt.Println(string(value))
 
 	// Output: Name                   Email                          Password         Age
-	// Priscilla Thornton     laurelmcclure@wiley.org        L43ypoSV1tDf     62
-	// Brooke Duncan          ramonblack@rutherford.io       rSM78E2ncUt3     9
-	// Gregg Ford             roxannewalsh@hamilton.name     DUB69zQ1WZx8     77
+	// Priscilla Thornton     laurelmcclure@wiley.org        93Ya9ABSa4kq     92
+	// Brooke Duncan          ramonblack@rutherford.io       US8ptM3c2T07     64
+	// Gregg Ford             roxannewalsh@hamilton.name     4wP4V90iMs44     59
 }
 
 func TestFixedWidthLookup(t *testing.T) {

--- a/internet_test.go
+++ b/internet_test.go
@@ -349,14 +349,14 @@ func ExampleFirefoxUserAgent() {
 	Seed(11)
 	fmt.Println(FirefoxUserAgent())
 
-	// Output: Mozilla/5.0 (Windows CE; en-US; rv:1.9.3.20) Gecko/2012-11-07 Firefox/36.0
+	// Output: Mozilla/5.0 (Windows CE; en-US; rv:1.9.3.20) Gecko/2013-11-07 Firefox/36.0
 }
 
 func ExampleFaker_FirefoxUserAgent() {
 	f := New(11)
 	fmt.Println(f.FirefoxUserAgent())
 
-	// Output: Mozilla/5.0 (Windows CE; en-US; rv:1.9.3.20) Gecko/2012-11-07 Firefox/36.0
+	// Output: Mozilla/5.0 (Windows CE; en-US; rv:1.9.3.20) Gecko/2013-11-07 Firefox/36.0
 }
 
 func BenchmarkFirefoxUserAgent(b *testing.B) {

--- a/json_test.go
+++ b/json_test.go
@@ -39,7 +39,7 @@ func ExampleJSON_object() {
 	//         "latitude": 77.259885,
 	//         "longitude": 101.656736
 	//     },
-	//     "password": "B4qp9aqaXYSA"
+	//     "password": "1VAfP4oi5DLy"
 	// }
 }
 
@@ -76,7 +76,7 @@ func ExampleFaker_JSON_object() {
 	//         "latitude": 77.259885,
 	//         "longitude": 101.656736
 	//     },
-	//     "password": "B4qp9aqaXYSA"
+	//     "password": "1VAfP4oi5DLy"
 	// }
 }
 
@@ -105,19 +105,19 @@ func ExampleJSON_array() {
 	//         "id": 1,
 	//         "first_name": "Priscilla",
 	//         "last_name": "Thornton",
-	//         "password": "3lGftNp9S908"
+	//         "password": "F395YfK9tHs9"
 	//     },
 	//     {
 	//         "id": 2,
-	//         "first_name": "Shaun",
-	//         "last_name": "Byrd",
-	//         "password": "Lc3G00tpPp7U"
+	//         "first_name": "Emmett",
+	//         "last_name": "Black",
+	//         "password": "PL0G37o1pY0p"
 	//     },
 	//     {
 	//         "id": 3,
-	//         "first_name": "Grady",
-	//         "last_name": "Craig",
-	//         "password": "LGAvzZ5xUB6Z"
+	//         "first_name": "Liza",
+	//         "last_name": "Vincent",
+	//         "password": "q11fR4MwsM4N"
 	//     }
 	// ]
 }
@@ -147,19 +147,19 @@ func ExampleFaker_JSON_array() {
 	//         "id": 1,
 	//         "first_name": "Priscilla",
 	//         "last_name": "Thornton",
-	//         "password": "3lGftNp9S908"
+	//         "password": "F395YfK9tHs9"
 	//     },
 	//     {
 	//         "id": 2,
-	//         "first_name": "Shaun",
-	//         "last_name": "Byrd",
-	//         "password": "Lc3G00tpPp7U"
+	//         "first_name": "Emmett",
+	//         "last_name": "Black",
+	//         "password": "PL0G37o1pY0p"
 	//     },
 	//     {
 	//         "id": 3,
-	//         "first_name": "Grady",
-	//         "last_name": "Craig",
-	//         "password": "LGAvzZ5xUB6Z"
+	//         "first_name": "Liza",
+	//         "last_name": "Vincent",
+	//         "password": "q11fR4MwsM4N"
 	//     }
 	// ]
 }

--- a/payment_test.go
+++ b/payment_test.go
@@ -101,7 +101,7 @@ func ExampleCreditCard() {
 
 	// Output: American Express
 	// 6376095989079994
-	// 06/30
+	// 06/31
 	// 125
 }
 
@@ -115,7 +115,7 @@ func ExampleFaker_CreditCard() {
 
 	// Output: American Express
 	// 6376095989079994
-	// 06/30
+	// 06/31
 	// 125
 }
 
@@ -216,14 +216,14 @@ func ExampleCreditCardExp() {
 	Seed(11)
 	fmt.Println(CreditCardExp())
 
-	// Output: 11/34
+	// Output: 11/35
 }
 
 func ExampleFaker_CreditCardExp() {
 	f := New(11)
 	fmt.Println(f.CreditCardExp())
 
-	// Output: 11/34
+	// Output: 11/35
 }
 
 func BenchmarkCreditCardExp(b *testing.B) {
@@ -296,14 +296,14 @@ func ExampleBitcoinAddress() {
 	Seed(11)
 	fmt.Println(BitcoinAddress())
 
-	// Output: 1Lcy9SN3ffStpUpP0VlGp4oD9G7t083012
+	// Output: 1X4a9BH9F9eSbFyq3qY9AYT54tpas2Kwf5
 }
 
 func ExampleFaker_BitcoinAddress() {
 	f := New(11)
 	fmt.Println(f.BitcoinAddress())
 
-	// Output: 1Lcy9SN3ffStpUpP0VlGp4oD9G7t083012
+	// Output: 1X4a9BH9F9eSbFyq3qY9AYT54tpas2Kwf5
 }
 
 func BenchmarkBitcoinAddress(b *testing.B) {

--- a/person_test.go
+++ b/person_test.go
@@ -410,7 +410,7 @@ func ExamplePerson() {
 	// elsareynolds@nichols.io
 	// American Express
 	// 4570938757201747
-	// 11/28
+	// 11/29
 	// 205
 }
 
@@ -473,7 +473,7 @@ func ExampleFaker_Person() {
 	// elsareynolds@nichols.io
 	// American Express
 	// 4570938757201747
-	// 11/28
+	// 11/29
 	// 205
 }
 

--- a/sql_test.go
+++ b/sql_test.go
@@ -23,7 +23,7 @@ func ExampleSQL() {
 
 	fmt.Println(string(res))
 
-	// Output: INSERT INTO people (id, first_name, price, age, created_at) VALUES (1, 'Priscilla', 985.96, 20, '1925-07-08 17:32:57'),(2, 'Ramon', 639.32, 74, '2017-12-29 07:25:24');
+	// Output: INSERT INTO people (id, first_name, price, age, created_at) VALUES (1, 'Priscilla', 985.96, 20, '1925-07-08 17:32:57'),(2, 'Ramon', 639.32, 74, '2018-12-29 07:25:24');
 }
 
 func ExampleFaker_SQL() {
@@ -43,7 +43,7 @@ func ExampleFaker_SQL() {
 
 	fmt.Println(string(res))
 
-	// Output: INSERT INTO people (id, first_name, price, age, created_at) VALUES (1, 'Priscilla', 985.96, 20, '1925-07-08 17:32:57'),(2, 'Ramon', 639.32, 74, '2017-12-29 07:25:24');
+	// Output: INSERT INTO people (id, first_name, price, age, created_at) VALUES (1, 'Priscilla', 985.96, 20, '1925-07-08 17:32:57'),(2, 'Ramon', 639.32, 74, '2018-12-29 07:25:24');
 }
 
 func TestSQLJSON(t *testing.T) {

--- a/xml_test.go
+++ b/xml_test.go
@@ -29,7 +29,7 @@ func ExampleXML_single() {
 	// Output: <xml>
 	//     <first_name>Priscilla</first_name>
 	//     <last_name>Thornton</last_name>
-	//     <password>3lGftNp9S908</password>
+	//     <password>F395YfK9tHs9</password>
 	// </xml>
 }
 
@@ -57,7 +57,7 @@ func ExampleFaker_XML_single() {
 	// Output: <xml>
 	//     <first_name>Priscilla</first_name>
 	//     <last_name>Thornton</last_name>
-	//     <password>3lGftNp9S908</password>
+	//     <password>F395YfK9tHs9</password>
 	// </xml>
 }
 
@@ -86,12 +86,12 @@ func ExampleXML_array() {
 	//     <record>
 	//         <first_name>Priscilla</first_name>
 	//         <last_name>Thornton</last_name>
-	//         <password>3lGftNp9S908</password>
+	//         <password>F395YfK9tHs9</password>
 	//     </record>
 	//     <record>
-	//         <first_name>Shaun</first_name>
-	//         <last_name>Byrd</last_name>
-	//         <password>Lc3G00tpPp7U</password>
+	//         <first_name>Emmett</first_name>
+	//         <last_name>Black</last_name>
+	//         <password>PL0G37o1pY0p</password>
 	//     </record>
 	// </xml>
 }
@@ -121,12 +121,12 @@ func ExampleFaker_XML_array() {
 	//     <record>
 	//         <first_name>Priscilla</first_name>
 	//         <last_name>Thornton</last_name>
-	//         <password>3lGftNp9S908</password>
+	//         <password>F395YfK9tHs9</password>
 	//     </record>
 	//     <record>
-	//         <first_name>Shaun</first_name>
-	//         <last_name>Byrd</last_name>
-	//         <password>Lc3G00tpPp7U</password>
+	//         <first_name>Emmett</first_name>
+	//         <last_name>Black</last_name>
+	//         <password>PL0G37o1pY0p</password>
 	//     </record>
 	// </xml>
 }


### PR DESCRIPTION
Fixes #356

## Problem
`Password(true, true, true, true, false, 12)` does not guarantee that
the output contains at least one character from each enabled set. The
function builds a weighted pool and draws all characters randomly, so
it's statistically possible to get a password with no uppercase, no
numeric, etc. This causes intermittent test failures in parallel test
suites.

## Fix
Reserve the first N positions in the byte slice (one per enabled
non-space group) with a guaranteed character from that group, then fill
remaining positions randomly from the full active pool, then shuffle.
This ensures every enabled character type is always represented, while
the final shuffle keeps the distribution random.

- Minimum password length is enforced at 5 (`auth.go:37`)
- There are at most 4 non-space groups (lower/upper/numeric/special)
- So there is always at least 1 remaining position for random fill

## Tests
Added `TestPasswordCharacterSetGuarantee` — runs 1000 iterations
asserting every password contains at least one char from each enabled
set. Updated `// Output:` comments across affected test files to reflect
the new RNG sequence.
